### PR TITLE
Fix JSON unmarshal errors for result-wrapped API responses

### DIFF
--- a/internal/api/api_collections.go
+++ b/internal/api/api_collections.go
@@ -24,11 +24,11 @@ func (s *apiCollectionService) List(ctx context.Context, opts *PaginationOptions
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result []APICollection
+	var result ResultList[APICollection]
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Result, nil
 }
 
 func (s *apiCollectionService) Create(ctx context.Context, name string, projectID int) (*APICollection, error) {

--- a/internal/api/api_collections_test.go
+++ b/internal/api/api_collections_test.go
@@ -17,7 +17,9 @@ func TestAPICollectionService_List(t *testing.T) {
 			t.Errorf("path = %s, want /api_collections", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]APICollection{{ID: 1, Name: "v1", Handle: "v1-handle", Version: "1.0", Description: "test collection", UsePrefix: true, ProjectID: 10}})
+		json.NewEncoder(w).Encode(map[string]any{
+				"result": []APICollection{{ID: 1, Name: "v1", Handle: "v1-handle", Version: "1.0", Description: "test collection", UsePrefix: true, ProjectID: 10}},
+			})
 	}))
 	defer srv.Close()
 

--- a/internal/api/api_endpoints.go
+++ b/internal/api/api_endpoints.go
@@ -28,11 +28,11 @@ func (s *apiEndpointService) List(ctx context.Context, collectionID *int, opts *
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result []APIEndpoint
+	var result ResultList[APIEndpoint]
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Result, nil
 }
 
 func (s *apiEndpointService) Enable(ctx context.Context, id int) error {

--- a/internal/api/api_endpoints_test.go
+++ b/internal/api/api_endpoints_test.go
@@ -17,7 +17,9 @@ func TestAPIEndpointService_List(t *testing.T) {
 			t.Errorf("api_collection_id = %q, want 5", cid)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]APIEndpoint{{ID: 1, Name: "ep1", APICollectionID: 5, Active: true, Method: "GET", Path: "/users", RecipeID: 42}})
+		json.NewEncoder(w).Encode(map[string]any{
+				"result": []APIEndpoint{{ID: 1, Name: "ep1", APICollectionID: 5, Active: true, Method: "GET", Path: "/users", RecipeID: 42}},
+			})
 	}))
 	defer srv.Close()
 

--- a/internal/api/connections.go
+++ b/internal/api/connections.go
@@ -28,11 +28,11 @@ func (s *connectionService) List(ctx context.Context, opts *ConnectionListOption
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result []Connection
+	var result ResultList[Connection]
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Result, nil
 }
 
 func (s *connectionService) Get(ctx context.Context, id int) (*Connection, error) {

--- a/internal/api/connectors.go
+++ b/internal/api/connectors.go
@@ -18,11 +18,9 @@ func (s *connectorService) List(ctx context.Context, search string) ([]Connector
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var wrapper struct {
-		Result []Connector `json:"result"`
-	}
-	if err := s.client.do(ctx, "GET", path, nil, &wrapper); err != nil {
+	var result ResultList[Connector]
+	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return wrapper.Result, nil
+	return result.Result, nil
 }

--- a/internal/api/folders.go
+++ b/internal/api/folders.go
@@ -20,11 +20,11 @@ func (s *folderService) List(ctx context.Context, parentID *int) ([]Folder, erro
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result []Folder
+	var result ResultList[Folder]
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Result, nil
 }
 
 func (s *folderService) Get(ctx context.Context, id int) (*Folder, error) {

--- a/internal/api/folders_test.go
+++ b/internal/api/folders_test.go
@@ -17,7 +17,9 @@ func TestFolderService_List(t *testing.T) {
 			t.Errorf("parent_id = %q, want 10", pid)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]Folder{{ID: 1, Name: "child"}})
+		json.NewEncoder(w).Encode(map[string]any{
+				"result": []Folder{{ID: 1, Name: "child"}},
+			})
 	}))
 	defer srv.Close()
 

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -28,11 +28,11 @@ func (s *tagService) List(ctx context.Context, opts *TagListOptions) ([]Tag, err
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result []Tag
+	var result ResultList[Tag]
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Result, nil
 }
 
 func (s *tagService) Create(ctx context.Context, title, description, color string) (*Tag, error) {

--- a/internal/api/tags_test.go
+++ b/internal/api/tags_test.go
@@ -20,7 +20,9 @@ func TestTagService_List(t *testing.T) {
 			t.Errorf("q = %q, want %q", q, "test")
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]Tag{{Handle: "h1", Title: "Tag 1"}})
+		json.NewEncoder(w).Encode(map[string]any{
+				"result": []Tag{{Handle: "h1", Title: "Tag 1"}},
+			})
 	}))
 	defer srv.Close()
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -73,10 +73,17 @@ type Job struct {
 	CompletedAt *time.Time `json:"completed_at,omitempty"`
 }
 
-// ListResult is a generic wrapper for paginated API responses.
-// Used by recipes (which return {"items":[...]}) but not connections/folders (which return bare arrays).
+// ListResult is a generic wrapper for paginated API responses
+// that return {"items":[...]}, e.g. recipes and jobs.
 type ListResult[T any] struct {
 	Items []T `json:"items"`
+}
+
+// ResultList is a generic wrapper for API responses that return
+// {"result":[...]}, e.g. tags, connections, folders, connectors,
+// api_collections, api_endpoints, members, and activity_logs.
+type ResultList[T any] struct {
+	Result []T `json:"result"`
 }
 
 // Tag represents a Workato tag.

--- a/internal/api/workspace.go
+++ b/internal/api/workspace.go
@@ -26,11 +26,11 @@ func (s *workspaceService) ListMembers(ctx context.Context, email string) ([]Wor
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result []WorkspaceUser
+	var result ResultList[WorkspaceUser]
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Result, nil
 }
 
 func (s *workspaceService) GetAuditLogs(ctx context.Context, opts *AuditLogOptions) ([]AuditLogEntry, error) {
@@ -50,9 +50,9 @@ func (s *workspaceService) GetAuditLogs(ctx context.Context, opts *AuditLogOptio
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result []AuditLogEntry
+	var result ResultList[AuditLogEntry]
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return result.Result, nil
 }

--- a/internal/api/workspace_test.go
+++ b/internal/api/workspace_test.go
@@ -37,7 +37,9 @@ func TestWorkspaceService_ListMembers(t *testing.T) {
 			t.Errorf("email = %q, want bob@example.com", r.URL.Query().Get("email"))
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]WorkspaceUser{{ID: 2, Name: "Bob", Email: "bob@example.com"}})
+		json.NewEncoder(w).Encode(map[string]any{
+				"result": []WorkspaceUser{{ID: 2, Name: "Bob", Email: "bob@example.com"}},
+			})
 	}))
 	defer srv.Close()
 
@@ -63,7 +65,9 @@ func TestWorkspaceService_GetAuditLogs(t *testing.T) {
 			t.Errorf("event_type = %q, want recipe_started", r.URL.Query().Get("event_type"))
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]AuditLogEntry{{ID: 1, EventType: "recipe_started", UserID: 10}})
+		json.NewEncoder(w).Encode(map[string]any{
+				"result": []AuditLogEntry{{ID: 1, EventType: "recipe_started", UserID: 10}},
+			})
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
 Fix JSON unmarshal errors for result-wrapped API responses

 Introduce generic ResultList[T] and apply it to tags, connectors,
 connections, folders, api_collections, api_endpoints, members, and
 audit_logs. Updates tests to match actual API envelope shape.

 Fixes #7, #8, #9, #10