### PR TITLE
Fixing remaining mis-mappings between api nomenclature and GO internals

### DIFF
--- a/internal/api/api_collections.go
+++ b/internal/api/api_collections.go
@@ -24,11 +24,11 @@ func (s *apiCollectionService) List(ctx context.Context, opts *PaginationOptions
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result ResultList[APICollection]
+	var result []APICollection
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return result.Result, nil
+	return result, nil
 }
 
 func (s *apiCollectionService) Create(ctx context.Context, name string, projectID int) (*APICollection, error) {

--- a/internal/api/api_endpoints.go
+++ b/internal/api/api_endpoints.go
@@ -28,11 +28,11 @@ func (s *apiEndpointService) List(ctx context.Context, collectionID *int, opts *
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result ResultList[APIEndpoint]
+	var result []APIEndpoint
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return result.Result, nil
+	return result, nil
 }
 
 func (s *apiEndpointService) Enable(ctx context.Context, id int) error {

--- a/internal/api/connections.go
+++ b/internal/api/connections.go
@@ -28,11 +28,11 @@ func (s *connectionService) List(ctx context.Context, opts *ConnectionListOption
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result ResultList[Connection]
+	var result []Connection
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return result.Result, nil
+	return result, nil
 }
 
 func (s *connectionService) Get(ctx context.Context, id int) (*Connection, error) {

--- a/internal/api/connectors.go
+++ b/internal/api/connectors.go
@@ -18,9 +18,11 @@ func (s *connectorService) List(ctx context.Context, search string) ([]Connector
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result ResultList[Connector]
-	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
+	var wrapper struct {
+		Items []Connector `json:"items"`
+	}
+	if err := s.client.do(ctx, "GET", path, nil, &wrapper); err != nil {
 		return nil, err
 	}
-	return result.Result, nil
+	return wrapper.Items, nil
 }

--- a/internal/api/folders.go
+++ b/internal/api/folders.go
@@ -20,11 +20,11 @@ func (s *folderService) List(ctx context.Context, parentID *int) ([]Folder, erro
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result ResultList[Folder]
+	var result []Folder
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
-	return result.Result, nil
+	return result, nil
 }
 
 func (s *folderService) Get(ctx context.Context, id int) (*Folder, error) {

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -28,11 +28,15 @@ func (s *tagService) List(ctx context.Context, opts *TagListOptions) ([]Tag, err
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result ResultList[Tag]
-	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
+	var wrapper struct {
+		Data struct {
+			Tags []Tag `json:"tags"`
+		} `json:"data"`
+	}
+	if err := s.client.do(ctx, "GET", path, nil, &wrapper); err != nil {
 		return nil, err
 	}
-	return result.Result, nil
+	return wrapper.Data.Tags, nil
 }
 
 func (s *tagService) Create(ctx context.Context, title, description, color string) (*Tag, error) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -79,13 +79,6 @@ type ListResult[T any] struct {
 	Items []T `json:"items"`
 }
 
-// ResultList is a generic wrapper for API responses that return
-// {"result":[...]}, e.g. tags, connections, folders, connectors,
-// api_collections, api_endpoints, members, and activity_logs.
-type ResultList[T any] struct {
-	Result []T `json:"result"`
-}
-
 // Tag represents a Workato tag.
 type Tag struct {
 	Handle      string `json:"handle"`
@@ -161,11 +154,15 @@ type WorkspaceUser struct {
 
 // AuditLogEntry represents a Workato audit log entry.
 type AuditLogEntry struct {
-	ID        int       `json:"id"`
-	EventType string    `json:"event_type"`
-	UserID    int       `json:"user_id"`
-	CreatedAt time.Time `json:"created_at"`
-	Details   any       `json:"details,omitempty"`
+	ID        int    `json:"id"`
+	EventType string `json:"event_type"`
+	Timestamp string `json:"timestamp"`
+	User      struct {
+		ID    int    `json:"id"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+	} `json:"user"`
+	Details any `json:"details,omitempty"`
 }
 
 // AuditLogOptions configures audit log filtering.

--- a/internal/api/workspace.go
+++ b/internal/api/workspace.go
@@ -26,11 +26,13 @@ func (s *workspaceService) ListMembers(ctx context.Context, email string) ([]Wor
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result ResultList[WorkspaceUser]
-	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
+	var wrapper struct {
+		Data []WorkspaceUser `json:"data"`
+	}
+	if err := s.client.do(ctx, "GET", path, nil, &wrapper); err != nil {
 		return nil, err
 	}
-	return result.Result, nil
+	return wrapper.Data, nil
 }
 
 func (s *workspaceService) GetAuditLogs(ctx context.Context, opts *AuditLogOptions) ([]AuditLogEntry, error) {
@@ -50,9 +52,11 @@ func (s *workspaceService) GetAuditLogs(ctx context.Context, opts *AuditLogOptio
 	if len(params) > 0 {
 		path += "?" + params.Encode()
 	}
-	var result ResultList[AuditLogEntry]
-	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
+	var wrapper struct {
+		Data []AuditLogEntry `json:"data"`
+	}
+	if err := s.client.do(ctx, "GET", path, nil, &wrapper); err != nil {
 		return nil, err
 	}
-	return result.Result, nil
+	return wrapper.Data, nil
 }

--- a/internal/commands/workspace.go
+++ b/internal/commands/workspace.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -126,14 +125,14 @@ func newWorkspaceAuditLogCmd() *cobra.Command {
 				return rctx.Formatter.Format(os.Stdout, entries)
 			}
 
-			headers := []string{"ID", "EVENT TYPE", "USER ID", "CREATED AT"}
+			headers := []string{"ID", "EVENT TYPE", "USER", "TIMESTAMP"}
 			var rows [][]string
 			for _, e := range entries {
 				rows = append(rows, []string{
 					strconv.Itoa(e.ID),
 					e.EventType,
-					strconv.Itoa(e.UserID),
-					e.CreatedAt.Format(time.RFC3339),
+					e.User.Email,
+					e.Timestamp,
 				})
 			}
 			return rctx.Formatter.FormatList(os.Stdout, headers, rows)


### PR DESCRIPTION
Fixes #9 and #10, as well as several unreported similiar issues, based on the use of a generic "Result" struct, invalid for all metadata types.