### PR TITLE
Adding sync refresh

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -45,10 +45,11 @@ type ConnectionListOptions struct {
 	PerPage  int
 }
 
-// FolderService defines operations on folders.
+// FolderService defines operations on folders. The Workato API does not
+// expose a single-folder-by-ID endpoint; callers that need to verify a
+// cached folder_id must walk the hierarchy via List and compare.
 type FolderService interface {
 	List(ctx context.Context, parentID *int) ([]Folder, error)
-	Get(ctx context.Context, id int) (*Folder, error)
 	Create(ctx context.Context, name string, parentID *int) (*Folder, error)
 	Delete(ctx context.Context, id int) error
 }

--- a/internal/api/folders.go
+++ b/internal/api/folders.go
@@ -27,14 +27,6 @@ func (s *folderService) List(ctx context.Context, parentID *int) ([]Folder, erro
 	return result, nil
 }
 
-func (s *folderService) Get(ctx context.Context, id int) (*Folder, error) {
-	var folder Folder
-	if err := s.client.do(ctx, "GET", fmt.Sprintf("/folders/%d", id), nil, &folder); err != nil {
-		return nil, err
-	}
-	return &folder, nil
-}
-
 func (s *folderService) Create(ctx context.Context, name string, parentID *int) (*Folder, error) {
 	body := map[string]any{"name": name}
 	if parentID != nil {

--- a/internal/commands/sync_group.go
+++ b/internal/commands/sync_group.go
@@ -21,6 +21,7 @@ content; the commands here manage the entries themselves.
 	}
 	cmd.AddCommand(newSyncAddCmd())
 	cmd.AddCommand(newSyncListCmd())
+	cmd.AddCommand(newSyncRefreshCmd())
 	cmd.AddCommand(newSyncRemoveCmd())
 	return cmd
 }

--- a/internal/commands/sync_refresh.go
+++ b/internal/commands/sync_refresh.go
@@ -1,0 +1,240 @@
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/workato-devs/wk-cli-beta/internal/config"
+	wkerrors "github.com/workato-devs/wk-cli-beta/internal/errors"
+	"github.com/workato-devs/wk-cli-beta/internal/sync"
+)
+
+// newSyncRefreshCmd reconciles cached folder_id values in wk.toml
+// against the current workspace state (ADR-007 Decision 11). It is the
+// postcommit companion to `wk init --verify` — same hierarchy walk,
+// same cache write-through. Cache validation is walk-based (the
+// Workato folders API has no single-folder-by-ID endpoint): each
+// entry's server_path is resolved and the result compared against
+// the cached folder_id.
+//
+// Exits zero even when some entries are not-found — partial results
+// are the useful outcome. --prune opts into removing the not-found
+// entries from wk.toml (interactive confirm or --yes).
+func newSyncRefreshCmd() *cobra.Command {
+	var (
+		flagPrune bool
+		flagYes   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "refresh",
+		Short: "Reconcile cached folder_id values against the workspace",
+		Long: `Walk every [[sync]] entry in wk.toml and classify it against current
+server state:
+
+  found       uncached entry — walk succeeded; cache populated with the
+              resolved folder_id (first-time lookup, no drift involved)
+  current     cached entry — walk returns the same folder_id; no change
+  repaired    cached entry — walk returned a different folder_id; the
+              cached value was wrong (renamed folder, recreated with a
+              new ID, etc.) and has been rewritten to the fresh ID
+  not-found   walk failed — server_path does not describe a real folder.
+              Entries that had a cached folder_id still show it in the
+              output so "used to work" stays distinct from "never
+              worked". --prune removes.
+
+Runs without push/pull traffic — folder-list API only. Partial results
+are a useful outcome, so refresh exits zero even when some entries are
+not-found. Use 'wk sync list' first if you only want to see cache
+state.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			if rctx.Config == nil {
+				return wkerrors.ErrNotInProject
+			}
+			if len(rctx.Config.Sync) == 0 {
+				if !rctx.Quiet && !flagJSON {
+					fmt.Fprintln(os.Stderr, "No [[sync]] entries to refresh.")
+				}
+				if flagJSON {
+					return rctx.Formatter.Format(os.Stdout, []sync.RefreshResult{})
+				}
+				return nil
+			}
+
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			engine := sync.NewSyncEngine(rctx.ProjectRoot, rctx.Config, client)
+			// Memoize GET /folders?parent_id=... for the duration of this
+			// sweep — N entries in the same workspace share folder lists at
+			// most parent_ids, so one fetch per unique parent beats N
+			// fetches of the same data.
+			engine.EnableFolderListCache()
+
+			results := make([]sync.RefreshResult, 0, len(rctx.Config.Sync))
+			entries := make([]config.SyncEntry, len(rctx.Config.Sync))
+			copy(entries, rctx.Config.Sync)
+			for _, entry := range entries {
+				r, err := engine.ClassifyEntry(cmd.Context(), entry)
+				if err != nil {
+					return err
+				}
+				results = append(results, r)
+			}
+
+			var foundCount, currentCount, repairedCount, notFoundCount int
+			for _, r := range results {
+				switch r.State {
+				case sync.RefreshStateFound:
+					foundCount++
+				case sync.RefreshStateCurrent:
+					currentCount++
+				case sync.RefreshStateRepaired:
+					repairedCount++
+				case sync.RefreshStateNotFound:
+					notFoundCount++
+				}
+			}
+
+			// Any "found" or "repaired" classifications mutated
+			// rctx.Config.Sync in place via ClassifyEntry's write-through.
+			// Persist once per sweep.
+			if foundCount+repairedCount > 0 {
+				if err := config.Save(config.ProjectConfigPath(rctx.ProjectRoot), rctx.Config); err != nil {
+					return fmt.Errorf("saving wk.toml: %w", err)
+				}
+			}
+
+			// Prune runs before the report so the JSON branch returns the
+			// full classification unchanged, but the human-readable prune
+			// summary line is deferred until AFTER the report so the
+			// ordering reads "classification → summary → prune outcome"
+			// rather than "prune outcome → classification" (which is
+			// confusing when the report still shows pruned rows).
+			pruneRemoved := 0
+			if flagPrune && notFoundCount > 0 {
+				if !flagYes {
+					if err := confirmPrune(cmd, results); err != nil {
+						return err
+					}
+				}
+				pruneRemoved = pruneEntries(rctx.Config, results)
+				if err := config.Save(config.ProjectConfigPath(rctx.ProjectRoot), rctx.Config); err != nil {
+					return fmt.Errorf("saving wk.toml after prune: %w", err)
+				}
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, results)
+			}
+
+			fmt.Fprintf(os.Stdout, "Refreshed %d sync entr%s:\n", len(results), pluralY(len(results)))
+			for _, r := range results {
+				switch r.State {
+				case sync.RefreshStateFound:
+					fmt.Fprintf(os.Stdout, "  found       %-40s  (folder_id=%d)\n", r.ServerPath, r.FolderID)
+				case sync.RefreshStateCurrent:
+					fmt.Fprintf(os.Stdout, "  current     %-40s  (folder_id=%d)\n", r.ServerPath, r.FolderID)
+				case sync.RefreshStateRepaired:
+					fmt.Fprintf(os.Stdout, "  repaired    %-40s  (folder_id=%d; %s)\n", r.ServerPath, r.FolderID, r.Message)
+				case sync.RefreshStateNotFound:
+					if r.FolderID != 0 {
+						fmt.Fprintf(os.Stdout, "  not-found   %-40s  (cached folder_id=%d; %s)\n", r.ServerPath, r.FolderID, r.Message)
+					} else {
+						fmt.Fprintf(os.Stdout, "  not-found   %-40s  (%s)\n", r.ServerPath, r.Message)
+					}
+				}
+			}
+			fmt.Fprintf(os.Stdout, "\nSummary: %d found, %d current, %d repaired, %d not-found.\n",
+				foundCount, currentCount, repairedCount, notFoundCount)
+			if pruneRemoved > 0 && !rctx.Quiet {
+				fmt.Fprintf(os.Stdout, "Pruned %d not-found entr%s from wk.toml.\n",
+					pruneRemoved, pluralY(pruneRemoved))
+			}
+			if notFoundCount > 0 && !flagPrune {
+				verb := "needs"
+				if notFoundCount != 1 {
+					verb = "need"
+				}
+				fmt.Fprintf(os.Stdout, "%d not-found entr%s %s attention. Run `wk sync refresh --prune` to remove.\n",
+					notFoundCount, pluralY(notFoundCount), verb)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&flagPrune, "prune", false,
+		"Remove not-found entries from wk.toml (requires confirmation or --yes)")
+	cmd.Flags().BoolVar(&flagYes, "yes", false,
+		"Skip the interactive confirmation prompt when --prune would remove entries")
+	return cmd
+}
+
+// confirmPrune lists the entries that --prune will remove and asks the
+// user to confirm. Errors if stdin is not a TTY — CI callers must pass
+// --yes to opt in without a prompt.
+func confirmPrune(cmd *cobra.Command, results []sync.RefreshResult) error {
+	var toRemove []sync.RefreshResult
+	for _, r := range results {
+		if r.State == sync.RefreshStateNotFound {
+			toRemove = append(toRemove, r)
+		}
+	}
+	if len(toRemove) == 0 {
+		return nil
+	}
+
+	if !isInteractiveStdin() || flagJSON || flagNoInput {
+		return fmt.Errorf("--prune would remove %d entr%s; pass --yes to confirm in non-interactive mode",
+			len(toRemove), pluralY(len(toRemove)))
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "The following %d entr%s will be removed from wk.toml:\n",
+		len(toRemove), pluralY(len(toRemove)))
+	for _, r := range toRemove {
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s  (%s)\n", r.ServerPath, r.State)
+	}
+	fmt.Fprint(cmd.OutOrStdout(), "Proceed? [y/N]: ")
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	if answer != "y" && answer != "yes" {
+		return fmt.Errorf("aborted: no entries removed")
+	}
+	return nil
+}
+
+// pruneEntries drops not-found entries from cfg.Sync and returns the
+// number removed. Matches on (server_path, local_path) so entries with
+// duplicate server_paths (possible under Decision 5 rule 3) are
+// disambiguated correctly.
+func pruneEntries(cfg *config.Config, results []sync.RefreshResult) int {
+	remove := make(map[string]bool, len(results))
+	for _, r := range results {
+		if r.State == sync.RefreshStateNotFound {
+			remove[r.ServerPath+"\x00"+r.LocalPath] = true
+		}
+	}
+	kept := cfg.Sync[:0]
+	removed := 0
+	for _, e := range cfg.Sync {
+		if remove[e.ServerPath+"\x00"+e.LocalPath] {
+			removed++
+			continue
+		}
+		kept = append(kept, e)
+	}
+	cfg.Sync = kept
+	return removed
+}

--- a/internal/commands/sync_refresh_test.go
+++ b/internal/commands/sync_refresh_test.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/workato-devs/wk-cli-beta/internal/config"
+	"github.com/workato-devs/wk-cli-beta/internal/sync"
+)
+
+// TestSyncRefresh_EmptyConfigNoCrash guards the early-exit path — with no
+// [[sync]] entries there is no API call to make, no config write, and the
+// command prints a message (or empty JSON) without touching the client.
+// Run under --json so we hit the JSON branch; the default path is
+// functionally identical for the zero case.
+func TestSyncRefresh_EmptyConfigNoCrash(t *testing.T) {
+	resetGlobalFlags(t)
+	cwd := setupIsolatedHome(t)
+	writeProjectSkel(t, cwd, nil)
+
+	flagJSON = true
+	t.Cleanup(func() { flagJSON = false })
+
+	root := NewRootCmd()
+	root.AddCommand(newSyncCmd())
+	root.SetArgs([]string{"sync", "refresh", "--json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+}
+
+// TestPruneEntries_RemovesNotFound pins the (server_path, local_path)
+// disambiguation logic so two entries with the same server path but
+// different local paths are correctly sorted into keep and remove
+// buckets. Only not-found entries are pruned — found/current/repaired
+// are all healthy outcomes.
+func TestPruneEntries_RemovesNotFound(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{
+			{ServerPath: "Good", LocalPath: "./good", FolderID: 10},
+			{ServerPath: "Same", LocalPath: "./same-a", FolderID: 20},
+			{ServerPath: "Same", LocalPath: "./same-b"},
+			{ServerPath: "Gone", LocalPath: "./gone", FolderID: 999},
+			{ServerPath: "Ghost", LocalPath: "./ghost"},
+			{ServerPath: "Renamed", LocalPath: "./renamed", FolderID: 50},
+		},
+	}
+	results := []sync.RefreshResult{
+		{ServerPath: "Good", LocalPath: "./good", State: sync.RefreshStateCurrent},
+		{ServerPath: "Same", LocalPath: "./same-a", State: sync.RefreshStateCurrent},
+		{ServerPath: "Same", LocalPath: "./same-b", State: sync.RefreshStateNotFound},
+		{ServerPath: "Gone", LocalPath: "./gone", State: sync.RefreshStateNotFound},
+		{ServerPath: "Ghost", LocalPath: "./ghost", State: sync.RefreshStateNotFound},
+		{ServerPath: "Renamed", LocalPath: "./renamed", State: sync.RefreshStateRepaired},
+	}
+
+	removed := pruneEntries(cfg, results)
+	if removed != 3 {
+		t.Errorf("removed = %d, want 3 (only not-found entries)", removed)
+	}
+	if len(cfg.Sync) != 3 {
+		t.Fatalf("remaining entries = %d, want 3 (%+v)", len(cfg.Sync), cfg.Sync)
+	}
+	keptPaths := map[string]bool{}
+	for _, e := range cfg.Sync {
+		keptPaths[e.ServerPath+"|"+e.LocalPath] = true
+	}
+	if !keptPaths["Good|./good"] {
+		t.Errorf("Good|./good should be kept (current): %+v", cfg.Sync)
+	}
+	if !keptPaths["Same|./same-a"] {
+		t.Errorf("Same|./same-a should be kept (current); only Same|./same-b should be pruned: %+v", cfg.Sync)
+	}
+	if !keptPaths["Renamed|./renamed"] {
+		t.Errorf("Renamed|./renamed should be kept (repaired, not pruned): %+v", cfg.Sync)
+	}
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -15,6 +16,48 @@ type SyncEngine struct {
 	config      *config.Config
 	packages    api.PackageService
 	folders     api.FolderService
+
+	// listCache memoizes GET /folders?parent_id=... responses for the
+	// lifetime of the engine instance. nil means the cache is disabled
+	// (normal pull/push/status — each call reaches the API freshly).
+	// EnableFolderListCache turns it on for multi-entry sweeps like
+	// `wk sync refresh`, where N entries would otherwise re-fetch the
+	// same folder list N times. Keys are parent_id (-1 for the implicit
+	// workspace root).
+	listCache map[int][]api.Folder
+}
+
+// EnableFolderListCache turns on per-parent List memoization for this
+// engine. Safe to call once before a batch of ClassifyEntry calls.
+// Pull/push/status should NOT enable this — they can see mid-run server
+// changes and must reach the API freshly.
+func (e *SyncEngine) EnableFolderListCache() {
+	if e.listCache == nil {
+		e.listCache = make(map[int][]api.Folder)
+	}
+}
+
+// listFolders is the cache-aware wrapper around e.folders.List. When the
+// cache is disabled (nil), it delegates directly; otherwise it memoizes
+// by parent_id and returns the cached slice on subsequent calls.
+func (e *SyncEngine) listFolders(ctx context.Context, parentID *int) ([]api.Folder, error) {
+	key := -1
+	if parentID != nil {
+		key = *parentID
+	}
+	if e.listCache != nil {
+		if cached, ok := e.listCache[key]; ok {
+			return cached, nil
+		}
+	}
+	folders, err := e.folders.List(ctx, parentID)
+	if err != nil {
+		return nil, err
+	}
+	if e.listCache != nil {
+		e.listCache[key] = folders
+	}
+	return folders, nil
 }
 
 // ignoreMatcher loads and returns the project's .wkignore matcher.

--- a/internal/sync/helpers.go
+++ b/internal/sync/helpers.go
@@ -63,6 +63,13 @@ func invalidFolderCacheErr(err error) bool {
 	return errors.Is(err, wkerrors.ErrAPINotFound)
 }
 
+// errPathNotResolved distinguishes "every List call succeeded but the
+// requested name was not present at the expected parent" from
+// API-level errors (auth, 5xx, network). Callers use errors.Is to
+// decide whether to classify an entry as not-found/stale vs. to
+// propagate the failure and halt a sweep.
+var errPathNotResolved = errors.New("folder path not resolved")
+
 // wrapFolderErr annotates a folder-resolution or API error with the sync
 // entry's server_path, cached folder_id, and (when available) the snapshot
 // workspace name, so developers can tell which [[sync]] entry failed and
@@ -107,7 +114,7 @@ func (e *SyncEngine) resolveFolderID(ctx context.Context, serverPath string) (in
 
 	var parentID *int
 	for _, name := range parts {
-		folders, err := e.folders.List(ctx, parentID)
+		folders, err := e.listFolders(ctx, parentID)
 		if err != nil {
 			return 0, fmt.Errorf("listing folders under %v: %w", parentID, err)
 		}
@@ -121,7 +128,7 @@ func (e *SyncEngine) resolveFolderID(ctx context.Context, serverPath string) (in
 			}
 		}
 		if !found {
-			return 0, fmt.Errorf("folder %q not found under parent %v", name, parentID)
+			return 0, fmt.Errorf("folder %q not found under parent %v: %w", name, parentID, errPathNotResolved)
 		}
 	}
 	return *parentID, nil

--- a/internal/sync/helpers_test.go
+++ b/internal/sync/helpers_test.go
@@ -22,10 +22,6 @@ func (m *mockFolderService) List(_ context.Context, parentID *int) ([]api.Folder
 	return m.folders[key], nil
 }
 
-func (m *mockFolderService) Get(_ context.Context, _ int) (*api.Folder, error) {
-	return nil, nil
-}
-
 func (m *mockFolderService) Create(_ context.Context, _ string, _ *int) (*api.Folder, error) {
 	return nil, nil
 }

--- a/internal/sync/refresh.go
+++ b/internal/sync/refresh.go
@@ -1,0 +1,121 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/workato-devs/wk-cli-beta/internal/config"
+)
+
+// RefreshState is the per-entry outcome of `wk sync refresh` (ADR-007
+// Decision 11). Values are stable across human and JSON output so
+// downstream scripts can branch on the string literally.
+type RefreshState string
+
+const (
+	// RefreshStateFound: entry had no cached folder_id and the walk
+	// succeeded. First-time resolution — no drift involved. The new ID
+	// has been written into the in-memory config slot; callers save
+	// once per sweep.
+	RefreshStateFound RefreshState = "found"
+
+	// RefreshStateCurrent: entry had a cached folder_id and the walk
+	// returned the same ID. No cache change needed.
+	RefreshStateCurrent RefreshState = "current"
+
+	// RefreshStateRepaired: entry had a cached folder_id but the walk
+	// returned a different ID (renamed folder, recreated with a new
+	// ID, workspace swap, etc.). Drift was detected; the cache has
+	// been rewritten with the fresh ID. CI monitors can alert on this
+	// state to see that the workspace changed underfoot.
+	RefreshStateRepaired RefreshState = "repaired"
+
+	// RefreshStateNotFound: walk failed — server_path does not describe
+	// a real folder. Reported; --prune removes. Entries that had a
+	// cached folder_id still show it in the output so the developer can
+	// see "used to work" vs "never worked"; the distinction is in the
+	// data, not in a separate state label.
+	RefreshStateNotFound RefreshState = "not-found"
+)
+
+// RefreshResult is the per-entry outcome emitted by ClassifyEntry.
+// ServerPath / LocalPath come from the incoming entry; FolderID is
+// either the resolved ID (found / current / repaired) or the cached ID
+// from before classification (not-found, so the developer can still
+// see what the local wk.toml had). Message carries a human detail
+// string for repaired / not-found; empty for found / current.
+type RefreshResult struct {
+	ServerPath string       `json:"server_path"`
+	LocalPath  string       `json:"local_path"`
+	FolderID   int          `json:"folder_id,omitempty"`
+	State      RefreshState `json:"state"`
+	Message    string       `json:"message,omitempty"`
+}
+
+// ClassifyEntry reconciles one [[sync]] entry against current server
+// state (ADR-007 Decision 11). The Workato API does not expose a
+// single-folder-by-ID endpoint, so cache validation happens by walking
+// the hierarchy via List and comparing the resolved leaf ID against
+// the cached value. On a fresh resolution (found) or cache repair
+// (repaired), writes the new folder_id into the matching config slot
+// in memory; callers persist via config.Save once the full sweep has
+// run.
+//
+// Returns a non-nil error only for genuine API failures (auth, 5xx,
+// network). "Name not present under expected parent" is distinguished
+// from API failure via the errPathNotResolved sentinel that
+// resolveFolderID wraps into its error, and classifies the entry as
+// not-found rather than halting the sweep.
+func (e *SyncEngine) ClassifyEntry(ctx context.Context, entry config.SyncEntry) (RefreshResult, error) {
+	result := RefreshResult{
+		ServerPath: entry.ServerPath,
+		LocalPath:  entry.LocalPath,
+		FolderID:   entry.FolderID,
+	}
+
+	id, err := e.resolveFolderID(ctx, entry.ServerPath)
+	if err != nil {
+		if !errors.Is(err, errPathNotResolved) {
+			return RefreshResult{}, fmt.Errorf("resolving %q: %w", entry.ServerPath, err)
+		}
+		result.State = RefreshStateNotFound
+		if entry.FolderID != 0 {
+			result.Message = fmt.Sprintf("cached folder_id=%d no longer resolves", entry.FolderID)
+		} else {
+			result.Message = fmt.Sprintf("server path %q does not resolve", entry.ServerPath)
+		}
+		return result, nil
+	}
+
+	if entry.FolderID == 0 {
+		result.State = RefreshStateFound
+		result.FolderID = id
+		e.writeCachedFolderID(entry.ServerPath, id)
+		return result, nil
+	}
+	if entry.FolderID == id {
+		result.State = RefreshStateCurrent
+		return result, nil
+	}
+
+	result.State = RefreshStateRepaired
+	result.FolderID = id
+	result.Message = fmt.Sprintf("cached folder_id changed from %d to %d", entry.FolderID, id)
+	e.writeCachedFolderID(entry.ServerPath, id)
+	return result, nil
+}
+
+// writeCachedFolderID updates the in-memory config slot for the
+// matching [[sync]] entry. Callers batch config.Save once per sweep.
+func (e *SyncEngine) writeCachedFolderID(serverPath string, id int) {
+	if e.config == nil {
+		return
+	}
+	for i := range e.config.Sync {
+		if e.config.Sync[i].ServerPath == serverPath {
+			e.config.Sync[i].FolderID = id
+			return
+		}
+	}
+}

--- a/internal/sync/refresh_test.go
+++ b/internal/sync/refresh_test.go
@@ -1,0 +1,304 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/workato-devs/wk-cli-beta/internal/api"
+	"github.com/workato-devs/wk-cli-beta/internal/config"
+)
+
+// refreshMockFolders lets each test case stub List behavior per-parent
+// and, when needed, inject a transient error to simulate API failure.
+// listCalls counts the total List invocations so tests can assert the
+// folder-list cache actually memoizes across entries.
+type refreshMockFolders struct {
+	list      map[int][]api.Folder
+	listErr   error
+	listCalls int
+}
+
+func (m *refreshMockFolders) List(_ context.Context, parentID *int) ([]api.Folder, error) {
+	m.listCalls++
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	key := -1
+	if parentID != nil {
+		key = *parentID
+	}
+	return m.list[key], nil
+}
+
+func (m *refreshMockFolders) Create(_ context.Context, _ string, _ *int) (*api.Folder, error) {
+	return nil, nil
+}
+
+func (m *refreshMockFolders) Delete(_ context.Context, _ int) error {
+	return nil
+}
+
+func newRefreshEngine(cfg *config.Config, folders *refreshMockFolders) *SyncEngine {
+	return &SyncEngine{
+		config:  cfg,
+		folders: folders,
+	}
+}
+
+// TestClassifyEntry_Found_UncachedWritesCache: entry starts with no
+// folder_id, the walk succeeds. First-time resolution — state is
+// "found", cache is populated.
+func TestClassifyEntry_Found_UncachedWritesCache(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "MyProject"}},
+	}
+	engine := newRefreshEngine(cfg, &refreshMockFolders{
+		list: map[int][]api.Folder{
+			-1: {{ID: 100, Name: "MyProject"}},
+		},
+	})
+
+	result, err := engine.ClassifyEntry(context.Background(), cfg.Sync[0])
+	if err != nil {
+		t.Fatalf("ClassifyEntry: %v", err)
+	}
+	if result.State != RefreshStateFound {
+		t.Errorf("state = %q, want %q", result.State, RefreshStateFound)
+	}
+	if result.FolderID != 100 {
+		t.Errorf("result.FolderID = %d, want 100", result.FolderID)
+	}
+	if cfg.Sync[0].FolderID != 100 {
+		t.Errorf("cfg.Sync[0].FolderID = %d, want 100 (in-memory write-through)", cfg.Sync[0].FolderID)
+	}
+}
+
+// TestClassifyEntry_Repaired_CachedMismatchRewritesCache: entry has a
+// cached folder_id but the walk returns a different ID (e.g. folder
+// was renamed or recreated). State is "repaired" — drift detected
+// and auto-healed. Cache is rewritten.
+func TestClassifyEntry_Repaired_CachedMismatchRewritesCache(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "MyProject", FolderID: 77}},
+	}
+	engine := newRefreshEngine(cfg, &refreshMockFolders{
+		list: map[int][]api.Folder{
+			-1: {{ID: 100, Name: "MyProject"}},
+		},
+	})
+
+	result, err := engine.ClassifyEntry(context.Background(), cfg.Sync[0])
+	if err != nil {
+		t.Fatalf("ClassifyEntry: %v", err)
+	}
+	if result.State != RefreshStateRepaired {
+		t.Errorf("state = %q, want %q", result.State, RefreshStateRepaired)
+	}
+	if result.FolderID != 100 {
+		t.Errorf("result.FolderID = %d, want 100", result.FolderID)
+	}
+	if !strings.Contains(result.Message, "77") || !strings.Contains(result.Message, "100") {
+		t.Errorf("message %q should mention both old (77) and new (100) IDs", result.Message)
+	}
+	if cfg.Sync[0].FolderID != 100 {
+		t.Errorf("cfg.Sync[0].FolderID = %d, want 100 (cache overwrote stale 77)", cfg.Sync[0].FolderID)
+	}
+}
+
+// TestClassifyEntry_Current_WalkMatchesCachedID: entry has a cached
+// folder_id AND the walk returns the same ID. No cache change needed.
+func TestClassifyEntry_Current_WalkMatchesCachedID(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "MyProject", FolderID: 100}},
+	}
+	engine := newRefreshEngine(cfg, &refreshMockFolders{
+		list: map[int][]api.Folder{
+			-1: {{ID: 100, Name: "MyProject"}},
+		},
+	})
+
+	result, err := engine.ClassifyEntry(context.Background(), cfg.Sync[0])
+	if err != nil {
+		t.Fatalf("ClassifyEntry: %v", err)
+	}
+	if result.State != RefreshStateCurrent {
+		t.Errorf("state = %q, want %q", result.State, RefreshStateCurrent)
+	}
+	if result.FolderID != 100 {
+		t.Errorf("result.FolderID = %d, want 100", result.FolderID)
+	}
+}
+
+// TestClassifyEntry_NotFound_CachedButWalkFails: entry has a cached
+// folder_id but the hierarchy no longer contains the path. Reported
+// as not-found with the cached id preserved in the output so the
+// developer can see "used to work, now gone". Cache is NOT mutated.
+func TestClassifyEntry_NotFound_CachedButWalkFails(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "Gone", FolderID: 999}},
+	}
+	engine := newRefreshEngine(cfg, &refreshMockFolders{
+		list: map[int][]api.Folder{
+			-1: {{ID: 100, Name: "RealProject"}},
+		},
+	})
+
+	result, err := engine.ClassifyEntry(context.Background(), cfg.Sync[0])
+	if err != nil {
+		t.Fatalf("ClassifyEntry: %v (not-found is a result, not an error)", err)
+	}
+	if result.State != RefreshStateNotFound {
+		t.Errorf("state = %q, want %q", result.State, RefreshStateNotFound)
+	}
+	if result.FolderID != 999 {
+		t.Errorf("result.FolderID = %d, want 999 (cached id preserved in output)", result.FolderID)
+	}
+	if !strings.Contains(result.Message, "999") {
+		t.Errorf("message %q should mention the cached id", result.Message)
+	}
+	if cfg.Sync[0].FolderID != 999 {
+		t.Errorf("cfg.Sync[0].FolderID = %d, want untouched 999", cfg.Sync[0].FolderID)
+	}
+}
+
+// TestClassifyEntry_NotFound_UncachedWalkFails: uncached entry whose
+// server_path does not describe a real folder. Reported with
+// folder_id=0 (nothing to report there) so the output differentiates
+// "never resolved" from "used to resolve".
+func TestClassifyEntry_NotFound_UncachedWalkFails(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "Ghost"}},
+	}
+	engine := newRefreshEngine(cfg, &refreshMockFolders{
+		list: map[int][]api.Folder{
+			-1: {{ID: 100, Name: "RealProject"}},
+		},
+	})
+
+	result, err := engine.ClassifyEntry(context.Background(), cfg.Sync[0])
+	if err != nil {
+		t.Fatalf("ClassifyEntry: %v (not-found is a result, not an error)", err)
+	}
+	if result.State != RefreshStateNotFound {
+		t.Errorf("state = %q, want %q", result.State, RefreshStateNotFound)
+	}
+	if result.FolderID != 0 {
+		t.Errorf("result.FolderID = %d, want 0 (no cache to preserve)", result.FolderID)
+	}
+	if cfg.Sync[0].FolderID != 0 {
+		t.Errorf("cfg.Sync[0].FolderID = %d, want untouched 0", cfg.Sync[0].FolderID)
+	}
+}
+
+// TestClassifyEntry_PropagatesAPIErrors confirms that API-level failures
+// (auth, 5xx, network) halt the sweep instead of being misclassified
+// as not-found. Only "name not present under expected parent" maps to
+// not-found.
+func TestClassifyEntry_PropagatesAPIErrors(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "Anything"}},
+	}
+	transient := errors.New("connection reset by peer")
+	engine := newRefreshEngine(cfg, &refreshMockFolders{
+		listErr: transient,
+	})
+
+	_, err := engine.ClassifyEntry(context.Background(), cfg.Sync[0])
+	if err == nil {
+		t.Fatal("err = nil, want non-nil for API failure")
+	}
+	if !errors.Is(err, transient) {
+		t.Errorf("err = %v, want to wrap transient %v", err, transient)
+	}
+}
+
+// TestClassifyEntry_ListCacheMemoizesAcrossEntries guards the perf fix
+// for `wk sync refresh`: N entries in the same workspace share the
+// top-level folder list, so enabling the list cache should collapse N
+// List calls into 1.
+func TestClassifyEntry_ListCacheMemoizesAcrossEntries(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{
+			{ServerPath: "Alpha"},
+			{ServerPath: "Beta"},
+			{ServerPath: "Gamma"},
+		},
+	}
+	folders := &refreshMockFolders{
+		list: map[int][]api.Folder{
+			-1: {
+				{ID: 1, Name: "Alpha"},
+				{ID: 2, Name: "Beta"},
+				{ID: 3, Name: "Gamma"},
+			},
+		},
+	}
+	engine := newRefreshEngine(cfg, folders)
+	engine.EnableFolderListCache()
+
+	for i := range cfg.Sync {
+		if _, err := engine.ClassifyEntry(context.Background(), cfg.Sync[i]); err != nil {
+			t.Fatalf("ClassifyEntry[%d]: %v", i, err)
+		}
+	}
+	if folders.listCalls != 1 {
+		t.Errorf("listCalls = %d, want 1 (cache should collapse 3 entries into one List)", folders.listCalls)
+	}
+}
+
+// TestClassifyEntry_ListCacheDisabledCallsEachTime pins the default —
+// normal operations (pull/push/status) should NOT share cached lists
+// because they can see mid-run server changes.
+func TestClassifyEntry_ListCacheDisabledCallsEachTime(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{
+			{ServerPath: "Alpha"},
+			{ServerPath: "Beta"},
+		},
+	}
+	folders := &refreshMockFolders{
+		list: map[int][]api.Folder{
+			-1: {
+				{ID: 1, Name: "Alpha"},
+				{ID: 2, Name: "Beta"},
+			},
+		},
+	}
+	engine := newRefreshEngine(cfg, folders)
+
+	for i := range cfg.Sync {
+		if _, err := engine.ClassifyEntry(context.Background(), cfg.Sync[i]); err != nil {
+			t.Fatalf("ClassifyEntry[%d]: %v", i, err)
+		}
+	}
+	if folders.listCalls != 2 {
+		t.Errorf("listCalls = %d, want 2 (cache disabled → one List per entry)", folders.listCalls)
+	}
+}
+
+// TestClassifyEntry_AllProjectsStripped covers the special-case root
+// path — uncached "All projects/..." still classifies as found and
+// writes the leaf ID.
+func TestClassifyEntry_AllProjectsStripped(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "All projects/MyProject"}},
+	}
+	engine := newRefreshEngine(cfg, &refreshMockFolders{
+		list: map[int][]api.Folder{
+			-1: {{ID: 100, Name: "MyProject"}},
+		},
+	})
+
+	result, err := engine.ClassifyEntry(context.Background(), cfg.Sync[0])
+	if err != nil {
+		t.Fatalf("ClassifyEntry: %v", err)
+	}
+	if result.State != RefreshStateFound {
+		t.Errorf("state = %q, want %q", result.State, RefreshStateFound)
+	}
+	if result.FolderID != 100 {
+		t.Errorf("FolderID = %d, want 100", result.FolderID)
+	}
+}


### PR DESCRIPTION
Adding refresh command to sync namespace, with folder service access. Supports 4-state model: found, current, repaired, not-found for .toml id sync against server.