### PR TITLE
Adding push create on demand, delete folder/project agnostic behavior

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -48,10 +48,15 @@ type ConnectionListOptions struct {
 // FolderService defines operations on folders. The Workato API does not
 // expose a single-folder-by-ID endpoint; callers that need to verify a
 // cached folder_id must walk the hierarchy via List and compare.
+//
+// Projects (is_project == true) use a separate DELETE endpoint and must
+// go through DeleteProject; plain folders use Delete. Callers inspect
+// Folder.IsProject from List results to route appropriately.
 type FolderService interface {
 	List(ctx context.Context, parentID *int) ([]Folder, error)
 	Create(ctx context.Context, name string, parentID *int) (*Folder, error)
 	Delete(ctx context.Context, id int) error
+	DeleteProject(ctx context.Context, id int) error
 }
 
 // PackageService defines operations on RLCM packages (export/import).

--- a/internal/api/folders.go
+++ b/internal/api/folders.go
@@ -42,3 +42,10 @@ func (s *folderService) Create(ctx context.Context, name string, parentID *int) 
 func (s *folderService) Delete(ctx context.Context, id int) error {
 	return s.client.do(ctx, "DELETE", fmt.Sprintf("/folders/%d", id), nil, nil)
 }
+
+// DeleteProject removes a top-level project via DELETE /projects/{id}.
+// The Workato folders DELETE endpoint does not handle projects;
+// callers must route by Folder.IsProject.
+func (s *folderService) DeleteProject(ctx context.Context, id int) error {
+	return s.client.do(ctx, "DELETE", fmt.Sprintf("/projects/%d", id), nil, nil)
+}

--- a/internal/api/folders_test.go
+++ b/internal/api/folders_test.go
@@ -76,3 +76,58 @@ func TestFolderService_Delete(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// TestFolderService_DeleteProject pins the separate endpoint that
+// projects (top-level, is_project=true) require. DELETE /folders/{id}
+// does not work for projects; DeleteProject routes to /projects/{id}.
+func TestFolderService_DeleteProject(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/projects/9" {
+			t.Errorf("path = %s, want /projects/9 (project delete must not route through /folders/)", r.URL.Path)
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	if err := client.Folders().DeleteProject(context.Background(), 9); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestFolder_DeserializesIsProjectAndProjectID ensures the list response
+// captures is_project AND the distinct project_id — folders-delete
+// routing depends on both: is_project picks the endpoint,
+// project_id is the value passed to DELETE /projects/{project_id}
+// (distinct from the folder's own id).
+func TestFolder_DeserializesIsProjectAndProjectID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"id":1,"name":"Proj","is_project":true,"project_id":42},{"id":2,"name":"Sub","is_project":false,"parent_id":1}]`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	folders, err := client.Folders().List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(folders) != 2 {
+		t.Fatalf("folders len = %d, want 2", len(folders))
+	}
+	if !folders[0].IsProject {
+		t.Errorf("folders[0].IsProject = false, want true")
+	}
+	if folders[0].ProjectID != 42 {
+		t.Errorf("folders[0].ProjectID = %d, want 42 (distinct from folder id=1)", folders[0].ProjectID)
+	}
+	if folders[1].IsProject {
+		t.Errorf("folders[1].IsProject = true, want false")
+	}
+	if folders[1].ProjectID != 0 {
+		t.Errorf("folders[1].ProjectID = %d, want 0 (plain folder, not a project)", folders[1].ProjectID)
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -43,11 +43,21 @@ type Connection struct {
 	UpdatedAt           time.Time `json:"updated_at"`
 }
 
-// Folder represents a Workato folder.
+// Folder represents a Workato folder. IsProject distinguishes top-level
+// projects from plain folders — the Workato workspace treats them as
+// the same resource shape on list, but delete routes differently:
+// projects require DELETE /projects/{project_id}; plain folders use
+// DELETE /folders/{id}.
+//
+// ProjectID is populated by the list response when IsProject is true
+// and is the identifier that DELETE /projects/... requires — distinct
+// from ID (the folder id) even when the folder IS a project.
 type Folder struct {
-	ID       int    `json:"id"`
-	Name     string `json:"name"`
-	ParentID *int   `json:"parent_id,omitempty"`
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	ParentID  *int   `json:"parent_id,omitempty"`
+	IsProject bool   `json:"is_project,omitempty"`
+	ProjectID int    `json:"project_id,omitempty"`
 }
 
 // Package represents an RLCM export/import package.

--- a/internal/api/types_coverage_test.go
+++ b/internal/api/types_coverage_test.go
@@ -67,7 +67,7 @@ func TestStructFieldCoverage(t *testing.T) {
 			name:       "Folder",
 			structType: reflect.TypeOf(Folder{}),
 			expectedFields: []string{
-				"id", "name", "parent_id",
+				"id", "name", "parent_id", "is_project", "project_id",
 			},
 		},
 		{

--- a/internal/commands/folder.go
+++ b/internal/commands/folder.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 
 	"github.com/spf13/cobra"
+
+	"github.com/workato-devs/wk-cli-beta/internal/api"
 )
 
 func newFoldersCmd() *cobra.Command {
@@ -114,8 +116,13 @@ func newFoldersCreateCmd() *cobra.Command {
 func newFoldersDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete <id>",
-		Short: "Delete a folder",
-		Args:  requireArgs(1, "folder ID is required, e.g.: wk folders delete <id>"),
+		Short: "Delete a folder or project",
+		Long: `Delete a top-level Workato project or a nested folder. The Workato
+API uses separate endpoints — DELETE /projects/{id} for projects
+(is_project=true), DELETE /folders/{id} for plain folders. This
+command lists top-level folders first and routes to the correct
+endpoint based on the target's is_project flag.`,
+		Args: requireArgs(1, "folder ID is required, e.g.: wk folders delete <id>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _, err := resolveAPIClient(cmd)
 			if err != nil {
@@ -127,10 +134,39 @@ func newFoldersDeleteCmd() *cobra.Command {
 				return fmt.Errorf("invalid folder ID: %s", args[0])
 			}
 
+			// Projects are always top-level; a single list call at the
+			// workspace root resolves both is_project and project_id. If
+			// the target isn't in the root list it's a nested folder,
+			// which always routes to DELETE /folders/{id}.
+			topLevel, err := client.Folders().List(cmd.Context(), nil)
+			if err != nil {
+				return fmt.Errorf("listing top-level folders to determine type: %w", err)
+			}
+			var match *api.Folder
+			for i, f := range topLevel {
+				if f.ID == id {
+					match = &topLevel[i]
+					break
+				}
+			}
+
+			if match != nil && match.IsProject {
+				// DELETE /projects/{project_id} — not folder_id. The
+				// project_id is a separate identifier returned on the
+				// folder list response when is_project=true.
+				if match.ProjectID == 0 {
+					return fmt.Errorf("folder %d is a project but the API did not return project_id; cannot route delete", id)
+				}
+				if err := client.Folders().DeleteProject(cmd.Context(), match.ProjectID); err != nil {
+					return err
+				}
+				fmt.Fprintf(os.Stdout, "Project %d deleted (project_id=%d)\n", id, match.ProjectID)
+				return nil
+			}
+
 			if err := client.Folders().Delete(cmd.Context(), id); err != nil {
 				return err
 			}
-
 			fmt.Fprintf(os.Stdout, "Folder %d deleted\n", id)
 			return nil
 		},

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -34,13 +34,15 @@ func resolveVerifyClient(cmd *cobra.Command, profileName string) (api.Client, er
 }
 
 // verifyServerPath walks the Workato folder hierarchy to confirm that
-// serverPath exists. On success returns the resolved leaf folder ID so
-// callers can populate the [[sync]] cache (ADR-007 Decision 7). Returns
-// 0 when serverPath resolves to the implicit workspace root.
-func verifyServerPath(cmd *cobra.Command, client api.Client, serverPath string) (int, error) {
+// serverPath exists. On success returns the resolved leaf folder so
+// callers can populate both folder_id AND project_id in the [[sync]]
+// cache (ADR-007 Decision 7; project_id is required by
+// DELETE /projects/{project_id}). Returns nil when serverPath resolves
+// to the implicit workspace root.
+func verifyServerPath(cmd *cobra.Command, client api.Client, serverPath string) (*api.Folder, error) {
 	parts := strings.Split(strings.Trim(serverPath, "/"), "/")
 	if len(parts) == 0 || parts[0] == "" {
-		return 0, fmt.Errorf("empty server path")
+		return nil, fmt.Errorf("empty server path")
 	}
 
 	// Strip implicit root folder "All projects" if present.
@@ -48,7 +50,7 @@ func verifyServerPath(cmd *cobra.Command, client api.Client, serverPath string) 
 		parts = parts[1:]
 	}
 	if len(parts) == 0 {
-		return 0, nil // root folder always exists
+		return nil, nil // root folder always exists
 	}
 
 	folders := client.Folders()
@@ -59,11 +61,11 @@ func verifyServerPath(cmd *cobra.Command, client api.Client, serverPath string) 
 	// by parent_id=nil would find nothing.
 	allFolders, err := folders.List(cmd.Context(), nil)
 	if err != nil {
-		return 0, fmt.Errorf("verifying server path: %w", err)
+		return nil, fmt.Errorf("verifying server path: %w", err)
 	}
 
 	var parentID *int
-	var leafID int
+	var leaf api.Folder
 	for _, name := range parts {
 		found := false
 		for _, f := range allFolders {
@@ -76,17 +78,17 @@ func verifyServerPath(cmd *cobra.Command, client api.Client, serverPath string) 
 			if parentID != nil && (f.ParentID == nil || *f.ParentID != *parentID) {
 				continue
 			}
+			leaf = f
 			id := f.ID
 			parentID = &id
-			leafID = id
 			found = true
 			break
 		}
 		if !found {
-			return 0, fmt.Errorf("server path %q not found: folder %q does not exist", serverPath, name)
+			return nil, fmt.Errorf("server path %q not found: folder %q does not exist", serverPath, name)
 		}
 	}
-	return leafID, nil
+	return &leaf, nil
 }
 
 func newInitCmd() *cobra.Command {
@@ -303,17 +305,19 @@ wk sync add/remove for incremental edits.`,
 				if err != nil {
 					return fmt.Errorf("--verify requires auth: %w", err)
 				}
-				// Populate folder_id cache during the walk so wk.toml lands
-				// fully adopted in one command (ADR-007 Decision 7). A leaf
-				// ID of 0 means the server path resolved to the workspace
-				// root — leave FolderID unset so omitempty keeps it out.
+				// Populate folder_id AND project_id cache during the walk
+				// so wk.toml lands fully adopted in one command (ADR-007
+				// Decision 7). A nil leaf means the server path resolved to
+				// the workspace root — leave IDs unset so omitempty keeps
+				// them out.
 				for i := range requested {
-					id, err := verifyServerPath(cmd, client, requested[i].ServerPath)
+					leaf, err := verifyServerPath(cmd, client, requested[i].ServerPath)
 					if err != nil {
 						return err
 					}
-					if id != 0 {
-						requested[i].FolderID = id
+					if leaf != nil {
+						requested[i].FolderID = leaf.ID
+						requested[i].ProjectID = leaf.ProjectID
 					}
 				}
 			}

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -97,13 +97,31 @@ func newPushCmd() *cobra.Command {
 		flagDryRun        bool
 		flagPreserveState bool
 		flagSkipHooks     bool
+		flagNoCreate      bool
+		flagCreatePath    bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "push",
 		Short: "Push local changes to remote workspace",
-		Long:  "Upload modified local assets to the Workato workspace.",
+		Long: `Upload modified local assets to the Workato workspace.
+
+When an entry's server_path does not yet exist on the workspace, push
+creates it (ADR-007 Decision 12). Gating:
+
+  --no-create        Disable auto-create entirely. Missing folders error.
+                     Recommended for CI / production deploys.
+  --create-path      Create every missing segment of a nested path, not
+                     just bare top-level names. Opt-in for deep hierarchies.
+
+Both gates are mutually exclusive. By default, a bare server_path
+(no slashes) is auto-created on first push; a nested path that does
+not resolve errors unless --create-path is passed.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if flagNoCreate && flagCreatePath {
+				return fmt.Errorf("--no-create and --create-path are mutually exclusive")
+			}
+
 			rctx, err := BuildRunContext(cmd)
 			if err != nil {
 				return err
@@ -132,6 +150,15 @@ func newPushCmd() *cobra.Command {
 			}
 
 			engine := sync.NewSyncEngine(rctx.ProjectRoot, rctx.Config, client)
+			switch {
+			case flagNoCreate:
+				engine.SetCreateMode(sync.CreateModeNever)
+			case flagCreatePath:
+				engine.SetCreateMode(sync.CreateModeAnyPath)
+			default:
+				engine.SetCreateMode(sync.CreateModeBareNames)
+			}
+
 			var allResults []sync.PushResult
 			for _, entry := range entries {
 				results, err := engine.Push(entry, flagDryRun, flagPreserveState)
@@ -139,6 +166,29 @@ func newPushCmd() *cobra.Command {
 					return err
 				}
 				allResults = append(allResults, results...)
+			}
+
+			created := engine.FoldersCreated()
+
+			// Loud creation reporting (ADR-007 Decision 14). stderr so it
+			// stays visible even when stdout is piped to a file or tool.
+			if !flagJSON && !rctx.Quiet {
+				for _, fc := range created {
+					fmt.Fprintf(os.Stderr, "Created server folder %q (folder_id=%d)\n", fc.ServerPath, fc.FolderID)
+				}
+			}
+
+			if flagJSON {
+				// Both fields emit as "[]" not "null" when empty so
+				// scripts can destructure without special-casing.
+				if allResults == nil {
+					allResults = []sync.PushResult{}
+				}
+				payload := map[string]any{
+					"folders_created": created,
+					"import_results":  allResults,
+				}
+				return rctx.Formatter.Format(os.Stdout, payload)
 			}
 
 			if len(allResults) == 0 {
@@ -165,6 +215,8 @@ func newPushCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "Show what would be pushed without uploading")
 	cmd.Flags().BoolVar(&flagPreserveState, "preserve-state", true, "Preserve recipe active state on import")
 	cmd.Flags().BoolVar(&flagSkipHooks, "skip-hooks", false, "Skip plugin pre-push hooks")
+	cmd.Flags().BoolVar(&flagNoCreate, "no-create", false, "Error instead of auto-creating missing server folders (ADR-007 Decision 13)")
+	cmd.Flags().BoolVar(&flagCreatePath, "create-path", false, "Create every missing segment of a nested server_path (not just bare names)")
 
 	return cmd
 }

--- a/internal/commands/sync_add.go
+++ b/internal/commands/sync_add.go
@@ -61,12 +61,13 @@ within one invocation are flagged as errors.`,
 					return fmt.Errorf("--verify requires auth: %w", verr)
 				}
 				for i := range requested {
-					id, err := verifyServerPath(cmd, client, requested[i].ServerPath)
+					leaf, err := verifyServerPath(cmd, client, requested[i].ServerPath)
 					if err != nil {
 						return err
 					}
-					if id != 0 {
-						requested[i].FolderID = id
+					if leaf != nil {
+						requested[i].FolderID = leaf.ID
+						requested[i].ProjectID = leaf.ProjectID
 					}
 				}
 			}

--- a/internal/commands/sync_push_test.go
+++ b/internal/commands/sync_push_test.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPush_NoCreateAndCreatePathAreMutuallyExclusive guards the flag
+// gate that runs before any API work — passing both contradicts each
+// other and should error early.
+func TestPush_NoCreateAndCreatePathAreMutuallyExclusive(t *testing.T) {
+	resetGlobalFlags(t)
+	_ = setupIsolatedHome(t)
+	writeProjectSkel(t, ".", nil)
+
+	root := NewRootCmd()
+	root.AddCommand(newPushCmd())
+	root.SetArgs([]string{"push", "--no-create", "--create-path"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("err = nil, want error (--no-create and --create-path are exclusive)")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("err = %v, want 'mutually exclusive'", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,10 +53,17 @@ type MCPConfig struct {
 // non-zero, sync operations skip the folder-hierarchy API walk. The
 // sync engine populates it on first resolution (write-through cache)
 // and invalidates + re-resolves on API 404. See ADR-005 Decision 9.
+//
+// ProjectID caches the distinct project identifier returned by the
+// Workato folders API when the target folder is a project
+// (is_project=true). Required for DELETE /projects/{project_id}, which
+// takes the project ID rather than the folder ID. Zero when the entry
+// points at a plain folder (not a project).
 type SyncEntry struct {
 	ServerPath string   `toml:"server_path"`
 	LocalPath  string   `toml:"local_path"`
 	FolderID   int      `toml:"folder_id,omitempty"`
+	ProjectID  int      `toml:"project_id,omitempty"`
 	Include    []string `toml:"include,omitempty"`
 }
 

--- a/internal/sync/create_test.go
+++ b/internal/sync/create_test.go
@@ -1,0 +1,359 @@
+package sync
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/workato-devs/wk-cli-beta/internal/api"
+	"github.com/workato-devs/wk-cli-beta/internal/config"
+)
+
+// createMockFolders mocks the Workato folders endpoint with a
+// live-updating tree: List reads from tree, Create adds a new entry
+// at the given parent and returns the assigned ID. Tests can inspect
+// listCalls / createCalls to assert on API traffic.
+type createMockFolders struct {
+	tree        map[int][]api.Folder // parentID -> children (-1 = root)
+	nextID      int
+	listCalls   int
+	createCalls int
+	createErr   error
+}
+
+func newCreateMock() *createMockFolders {
+	return &createMockFolders{
+		tree:   map[int][]api.Folder{-1: nil},
+		nextID: 100,
+	}
+}
+
+func (m *createMockFolders) List(_ context.Context, parentID *int) ([]api.Folder, error) {
+	m.listCalls++
+	key := -1
+	if parentID != nil {
+		key = *parentID
+	}
+	return m.tree[key], nil
+}
+
+func (m *createMockFolders) Create(_ context.Context, name string, parentID *int) (*api.Folder, error) {
+	m.createCalls++
+	if m.createErr != nil {
+		return nil, m.createErr
+	}
+	key := -1
+	if parentID != nil {
+		key = *parentID
+	}
+	folder := api.Folder{ID: m.nextID, Name: name, ParentID: parentID}
+	// Mirror the Workato API: a create at root with no parent is a
+	// project and gets a distinct project_id. Nested creates are plain
+	// folders (project_id stays 0).
+	if parentID == nil {
+		folder.IsProject = true
+		folder.ProjectID = m.nextID + 1000
+	}
+	m.nextID++
+	m.tree[key] = append(m.tree[key], folder)
+	return &folder, nil
+}
+
+func (m *createMockFolders) Delete(_ context.Context, _ int) error {
+	return nil
+}
+
+func (m *createMockFolders) DeleteProject(_ context.Context, _ int) error {
+	return nil
+}
+
+func newCreateEngine(cfg *config.Config, folders *createMockFolders) *SyncEngine {
+	return &SyncEngine{
+		config:  cfg,
+		folders: folders,
+	}
+}
+
+// TestCreateForEntry_BareNameDefault: default mode (CreateModeBareNames)
+// creates a missing top-level folder on first push. One API create,
+// one FolderCreated record, cache populated.
+func TestCreateForEntry_BareNameDefault(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "MyProject"}},
+	}
+	folders := newCreateMock()
+	engine := newCreateEngine(cfg, folders)
+
+	id, err := engine.createForEntry(context.Background(), "MyProject")
+	if err != nil {
+		t.Fatalf("createForEntry: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("id = 0, want non-zero")
+	}
+	if folders.createCalls != 1 {
+		t.Errorf("createCalls = %d, want 1", folders.createCalls)
+	}
+	if len(engine.foldersCreated) != 1 {
+		t.Fatalf("foldersCreated len = %d, want 1", len(engine.foldersCreated))
+	}
+	if engine.foldersCreated[0].ServerPath != "MyProject" {
+		t.Errorf("foldersCreated[0].ServerPath = %q, want MyProject", engine.foldersCreated[0].ServerPath)
+	}
+	if cfg.Sync[0].FolderID != id {
+		t.Errorf("cfg.Sync[0].FolderID = %d, want %d (write-through cache)", cfg.Sync[0].FolderID, id)
+	}
+}
+
+// TestCreateForEntry_NestedPathDefaultErrors: nested path + default
+// mode errors loudly rather than silently creating a multi-level
+// hierarchy (Decision 13 — nested miss is more likely a typo than
+// intent).
+func TestCreateForEntry_NestedPathDefaultErrors(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "Clients/Acme/Prod"}},
+	}
+	engine := newCreateEngine(cfg, newCreateMock())
+
+	_, err := engine.createForEntry(context.Background(), "Clients/Acme/Prod")
+	if err == nil {
+		t.Fatal("err = nil, want error (nested path missing, default mode)")
+	}
+	if !strings.Contains(err.Error(), "--create-path") {
+		t.Errorf("err = %v, want hint about --create-path", err)
+	}
+}
+
+// TestCreateForEntry_NestedPathWithCreatePath: --create-path walks
+// the tree and creates each missing segment. All three creates are
+// recorded with their cumulative server_path.
+func TestCreateForEntry_NestedPathWithCreatePath(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "Clients/Acme/Prod"}},
+	}
+	folders := newCreateMock()
+	engine := newCreateEngine(cfg, folders)
+	engine.SetCreateMode(CreateModeAnyPath)
+
+	id, err := engine.createForEntry(context.Background(), "Clients/Acme/Prod")
+	if err != nil {
+		t.Fatalf("createForEntry: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("id = 0, want non-zero")
+	}
+	if folders.createCalls != 3 {
+		t.Errorf("createCalls = %d, want 3", folders.createCalls)
+	}
+	if len(engine.foldersCreated) != 3 {
+		t.Fatalf("foldersCreated len = %d, want 3", len(engine.foldersCreated))
+	}
+	wantPaths := []string{"Clients", "Clients/Acme", "Clients/Acme/Prod"}
+	for i, want := range wantPaths {
+		if engine.foldersCreated[i].ServerPath != want {
+			t.Errorf("foldersCreated[%d].ServerPath = %q, want %q", i, engine.foldersCreated[i].ServerPath, want)
+		}
+	}
+}
+
+// TestCreateForEntry_NoCreateErrors: --no-create disables the fallback
+// entirely — any missing folder surfaces as an error.
+func TestCreateForEntry_NoCreateErrors(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "MyProject"}},
+	}
+	folders := newCreateMock()
+	engine := newCreateEngine(cfg, folders)
+	engine.SetCreateMode(CreateModeNever)
+
+	_, err := engine.createForEntry(context.Background(), "MyProject")
+	if err == nil {
+		t.Fatal("err = nil, want error (--no-create set)")
+	}
+	if !strings.Contains(err.Error(), "--no-create") {
+		t.Errorf("err = %v, want mention of --no-create", err)
+	}
+	if folders.createCalls != 0 {
+		t.Errorf("createCalls = %d, want 0 (no-create must never call Create)", folders.createCalls)
+	}
+}
+
+// TestCreateForEntry_AllProjectsPrefixStripped: "All projects/X" is a
+// bare name after the prefix strip, so default mode still creates.
+func TestCreateForEntry_AllProjectsPrefixStripped(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "All projects/MyProject"}},
+	}
+	folders := newCreateMock()
+	engine := newCreateEngine(cfg, folders)
+
+	id, err := engine.createForEntry(context.Background(), "All projects/MyProject")
+	if err != nil {
+		t.Fatalf("createForEntry: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("id = 0, want non-zero")
+	}
+	if folders.createCalls != 1 {
+		t.Errorf("createCalls = %d, want 1", folders.createCalls)
+	}
+}
+
+// TestCreateForEntry_UsesExistingParentWithCreatePath: when
+// --create-path walks a path whose ancestors already exist, only the
+// missing segments are created. Existing ones are reused.
+func TestCreateForEntry_UsesExistingParentWithCreatePath(t *testing.T) {
+	folders := newCreateMock()
+	// Seed an existing "Clients" top-level so only "Acme" and "Prod"
+	// need to be created.
+	folders.tree[-1] = []api.Folder{{ID: 50, Name: "Clients"}}
+
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "Clients/Acme/Prod"}},
+	}
+	engine := newCreateEngine(cfg, folders)
+	engine.SetCreateMode(CreateModeAnyPath)
+
+	_, err := engine.createForEntry(context.Background(), "Clients/Acme/Prod")
+	if err != nil {
+		t.Fatalf("createForEntry: %v", err)
+	}
+	if folders.createCalls != 2 {
+		t.Errorf("createCalls = %d, want 2 (only Acme and Prod should be created)", folders.createCalls)
+	}
+	if len(engine.foldersCreated) != 2 {
+		t.Fatalf("foldersCreated len = %d, want 2 (%+v)", len(engine.foldersCreated), engine.foldersCreated)
+	}
+}
+
+// TestFolderIDForEntry_CreateFallbackIntegration verifies the end-to-end
+// flow: uncached entry -> walk fails -> create -> ID returned + cached.
+// This is the wiring that turns greenfield `wk init` + `wk push` into
+// a working two-command flow (ADR-007 Decision 12).
+func TestFolderIDForEntry_CreateFallbackIntegration(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "GreenfieldProject"}},
+	}
+	folders := newCreateMock()
+	engine := newCreateEngine(cfg, folders)
+
+	id, err := engine.folderIDForEntry(context.Background(), cfg.Sync[0])
+	if err != nil {
+		t.Fatalf("folderIDForEntry: %v", err)
+	}
+	if id == 0 {
+		t.Fatal("id = 0, want non-zero")
+	}
+	if folders.createCalls != 1 {
+		t.Errorf("createCalls = %d, want 1", folders.createCalls)
+	}
+	if cfg.Sync[0].FolderID != id {
+		t.Errorf("cfg.Sync[0].FolderID = %d, want %d", cfg.Sync[0].FolderID, id)
+	}
+}
+
+// TestFolderIDForEntry_CacheHitSkipsCreate: cached entry is a fast
+// path — no walk, no create, no API traffic.
+func TestFolderIDForEntry_CacheHitSkipsCreate(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "Cached", FolderID: 42}},
+	}
+	folders := newCreateMock()
+	engine := newCreateEngine(cfg, folders)
+
+	id, err := engine.folderIDForEntry(context.Background(), cfg.Sync[0])
+	if err != nil {
+		t.Fatalf("folderIDForEntry: %v", err)
+	}
+	if id != 42 {
+		t.Errorf("id = %d, want cached 42", id)
+	}
+	if folders.listCalls != 0 || folders.createCalls != 0 {
+		t.Errorf("listCalls=%d createCalls=%d, want both 0 (cache hit should be silent)", folders.listCalls, folders.createCalls)
+	}
+}
+
+// TestFoldersCreated_NeverReturnsNil guards the JSON-serialization
+// fix: an engine that never created anything should still return a
+// non-nil (empty) slice so `folders_created` marshals as "[]" in the
+// push JSON envelope, not "null".
+func TestFoldersCreated_NeverReturnsNil(t *testing.T) {
+	engine := newCreateEngine(&config.Config{}, newCreateMock())
+	if got := engine.FoldersCreated(); got == nil {
+		t.Fatal("FoldersCreated() = nil; want non-nil empty slice for JSON consumers")
+	}
+	if got := engine.FoldersCreated(); len(got) != 0 {
+		t.Errorf("FoldersCreated() len = %d, want 0", len(got))
+	}
+}
+
+// TestCreateForEntry_CapturesProjectID guards the project_id
+// threading: when push creates a top-level project, both folder_id
+// AND project_id must land in wk.toml so wk folders delete has the
+// right value for DELETE /projects/{project_id}.
+func TestCreateForEntry_CapturesProjectID(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "MyProject"}},
+	}
+	folders := newCreateMock()
+	engine := newCreateEngine(cfg, folders)
+
+	if _, err := engine.createForEntry(context.Background(), "MyProject"); err != nil {
+		t.Fatalf("createForEntry: %v", err)
+	}
+
+	if cfg.Sync[0].FolderID == 0 {
+		t.Errorf("cfg.Sync[0].FolderID = 0, want non-zero")
+	}
+	if cfg.Sync[0].ProjectID == 0 {
+		t.Errorf("cfg.Sync[0].ProjectID = 0, want non-zero (project_id must be captured from Create response)")
+	}
+	if cfg.Sync[0].FolderID == cfg.Sync[0].ProjectID {
+		t.Errorf("FolderID == ProjectID (%d); want distinct values", cfg.Sync[0].FolderID)
+	}
+
+	created := engine.FoldersCreated()
+	if len(created) != 1 {
+		t.Fatalf("FoldersCreated len = %d, want 1", len(created))
+	}
+	if created[0].ProjectID == 0 {
+		t.Errorf("FoldersCreated[0].ProjectID = 0, want non-zero")
+	}
+}
+
+// TestCreateForEntry_NestedFolderHasNoProjectID: nested creates are
+// plain folders (not projects). project_id stays zero for them —
+// only the top-level project segment should carry one.
+func TestCreateForEntry_NestedFolderHasNoProjectID(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "Clients/Acme/Prod"}},
+	}
+	folders := newCreateMock()
+	engine := newCreateEngine(cfg, folders)
+	engine.SetCreateMode(CreateModeAnyPath)
+
+	if _, err := engine.createForEntry(context.Background(), "Clients/Acme/Prod"); err != nil {
+		t.Fatalf("createForEntry: %v", err)
+	}
+
+	created := engine.FoldersCreated()
+	if len(created) != 3 {
+		t.Fatalf("FoldersCreated len = %d, want 3", len(created))
+	}
+	// First segment is the project (created at root).
+	if created[0].ProjectID == 0 {
+		t.Errorf("top-level Clients should have project_id set")
+	}
+	// Nested segments are plain folders.
+	for i, c := range created[1:] {
+		if c.ProjectID != 0 {
+			t.Errorf("nested segment %d (%s) got ProjectID=%d, want 0", i+1, c.ServerPath, c.ProjectID)
+		}
+	}
+
+	// Leaf entry in cfg reflects the deepest folder, which is a plain
+	// folder, so its ProjectID should be zero.
+	if cfg.Sync[0].ProjectID != 0 {
+		t.Errorf("cfg.Sync[0].ProjectID = %d, want 0 (leaf is nested, not a project)", cfg.Sync[0].ProjectID)
+	}
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -9,6 +9,40 @@ import (
 	"github.com/workato-devs/wk-cli-beta/internal/config"
 )
 
+// CreateMode controls folderIDForEntry's fallback behavior when the
+// hierarchy walk fails to resolve an entry's server_path (ADR-007
+// Decision 13). Default (zero value) is CreateModeBareNames.
+type CreateMode int
+
+const (
+	// CreateModeBareNames creates a missing top-level folder when the
+	// server_path has no slashes — the greenfield pattern. Nested paths
+	// still error; auto-creating a multi-level tree on first push is
+	// more likely to mask a typo than to match intent.
+	CreateModeBareNames CreateMode = iota
+
+	// CreateModeNever disables auto-create entirely. Any missing folder
+	// surfaces as an error. The --no-create CI escape hatch.
+	CreateModeNever
+
+	// CreateModeAnyPath creates missing folders at any depth, walking
+	// parents and creating each segment in order. The --create-path
+	// escape hatch for deliberately spinning up a nested hierarchy.
+	CreateModeAnyPath
+)
+
+// FolderCreated records one server-side folder creation triggered by
+// push's resolve-then-create branch (ADR-007 Decision 14). One record
+// per API call — under --create-path a single entry may produce
+// multiple records (one per missing segment). ProjectID is non-zero
+// when the API marked the created folder as a project (is_project=true);
+// it is the separate identifier required by DELETE /projects/{project_id}.
+type FolderCreated struct {
+	ServerPath string `json:"server_path"`
+	FolderID   int    `json:"folder_id"`
+	ProjectID  int    `json:"project_id,omitempty"`
+}
+
 // SyncEngine coordinates pull, push, status, and diff operations
 // between the local project directory and the Workato workspace.
 type SyncEngine struct {
@@ -25,6 +59,17 @@ type SyncEngine struct {
 	// same folder list N times. Keys are parent_id (-1 for the implicit
 	// workspace root).
 	listCache map[int][]api.Folder
+
+	// createMode controls folderIDForEntry's fallback when the walk
+	// returns errPathNotResolved. Zero value = CreateModeBareNames.
+	// Set by the push command after flag parsing.
+	createMode CreateMode
+
+	// foldersCreated accumulates server-folder creations from push's
+	// resolve-then-create branch so the command layer can report them
+	// loudly (ADR-007 Decision 14). Reset is caller-scoped — engines
+	// are per-command-run, so a fresh one always starts empty.
+	foldersCreated []FolderCreated
 }
 
 // EnableFolderListCache turns on per-parent List memoization for this
@@ -35,6 +80,42 @@ func (e *SyncEngine) EnableFolderListCache() {
 	if e.listCache == nil {
 		e.listCache = make(map[int][]api.Folder)
 	}
+}
+
+// SetCreateMode configures how folderIDForEntry handles a failed walk
+// for uncached entries. Call once during command setup, after flag
+// parsing. Default (zero value) is CreateModeBareNames.
+func (e *SyncEngine) SetCreateMode(mode CreateMode) {
+	e.createMode = mode
+}
+
+// FoldersCreated returns the server-folder creations that have
+// happened during this engine's lifetime. Reset is caller-scoped: a
+// fresh engine always starts empty. Safe to call once after all Push
+// invocations complete.
+//
+// Always returns a non-nil slice so JSON consumers see "[]" rather
+// than "null" when nothing was created — keeps scripts that destructure
+// folders_created from having to special-case the empty case.
+func (e *SyncEngine) FoldersCreated() []FolderCreated {
+	if e.foldersCreated == nil {
+		return []FolderCreated{}
+	}
+	return e.foldersCreated
+}
+
+// invalidateListCacheFor drops the cached folder list for parentID
+// after a create under that parent. Subsequent resolves in this sweep
+// will see the new folder. No-op when the cache is disabled.
+func (e *SyncEngine) invalidateListCacheFor(parentID *int) {
+	if e.listCache == nil {
+		return
+	}
+	key := -1
+	if parentID != nil {
+		key = *parentID
+	}
+	delete(e.listCache, key)
 }
 
 // listFolders is the cache-aware wrapper around e.folders.List. When the

--- a/internal/sync/helpers.go
+++ b/internal/sync/helpers.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/workato-devs/wk-cli-beta/internal/api"
 	"github.com/workato-devs/wk-cli-beta/internal/config"
 	wkerrors "github.com/workato-devs/wk-cli-beta/internal/errors"
 )
@@ -21,39 +22,139 @@ const pollInterval = 2 * time.Second
 // It does not correspond to an actual API folder.
 const implicitRootFolder = "All projects"
 
-// folderIDForEntry returns the Workato folder ID for entry. If the entry
-// has a cached FolderID (non-zero), it is returned without any API calls.
-// Otherwise the path is resolved via the folder-hierarchy walk and the ID
-// is written back to wk.toml as a write-through cache (ADR-005 Decision 9).
+// folderIDForEntry returns the Workato folder ID for entry. If the
+// entry has a cached FolderID (non-zero), it is returned without any
+// API calls. Otherwise the path is resolved via the folder-hierarchy
+// walk and the ID is written back to wk.toml as a write-through cache
+// (ADR-005 Decision 9). When the walk fails with errPathNotResolved,
+// push's resolve-then-create branch (ADR-007 Decision 12) kicks in
+// per the engine's createMode.
 func (e *SyncEngine) folderIDForEntry(ctx context.Context, entry config.SyncEntry) (int, error) {
 	if entry.FolderID != 0 {
 		return entry.FolderID, nil
 	}
-	return e.resolveAndCache(ctx, entry.ServerPath)
-}
-
-// resolveAndCache walks the folder hierarchy to resolve serverPath and
-// persists the resulting ID to the matching [[sync]] entry in wk.toml.
-// Cache write failures are logged but non-fatal — the ID is still returned.
-func (e *SyncEngine) resolveAndCache(ctx context.Context, serverPath string) (int, error) {
-	id, err := e.resolveFolderID(ctx, serverPath)
-	if err != nil {
+	id, err := e.resolveAndCache(ctx, entry.ServerPath)
+	if err == nil {
+		return id, nil
+	}
+	if !errors.Is(err, errPathNotResolved) {
 		return 0, err
 	}
-	if e.config != nil {
-		for i := range e.config.Sync {
-			if e.config.Sync[i].ServerPath == serverPath {
-				e.config.Sync[i].FolderID = id
+	return e.createForEntry(ctx, entry.ServerPath)
+}
+
+// createForEntry implements the resolve-then-create fallback for
+// push (ADR-007 Decisions 12–13). Gating:
+//   - CreateModeNever         — error on any missing segment.
+//   - CreateModeBareNames     — create only if server_path is a bare
+//                               name (no slashes); nested missing paths
+//                               error.
+//   - CreateModeAnyPath       — walk the hierarchy, creating each
+//                               missing segment in order.
+//
+// Every API create is recorded on e.foldersCreated so the command
+// layer can surface the events. The cached list for each parent is
+// invalidated after a create so subsequent resolves in the same sweep
+// see the new folder.
+func (e *SyncEngine) createForEntry(ctx context.Context, serverPath string) (int, error) {
+	if e.createMode == CreateModeNever {
+		return 0, fmt.Errorf("folder %q not found and --no-create was set", serverPath)
+	}
+
+	parts := strings.Split(strings.Trim(serverPath, "/"), "/")
+	if len(parts) > 0 && strings.EqualFold(parts[0], implicitRootFolder) {
+		parts = parts[1:]
+	}
+	if len(parts) == 0 {
+		return 0, fmt.Errorf("cannot create the implicit workspace root")
+	}
+
+	if len(parts) > 1 && e.createMode != CreateModeAnyPath {
+		return 0, fmt.Errorf("nested path %q does not resolve; pass --create-path to create the full hierarchy", serverPath)
+	}
+
+	var parentID *int
+	var leafFolderID, leafProjectID int
+	for i, name := range parts {
+		folders, err := e.listFolders(ctx, parentID)
+		if err != nil {
+			return 0, fmt.Errorf("listing folders under %v: %w", parentID, err)
+		}
+		found := false
+		for _, f := range folders {
+			if strings.EqualFold(f.Name, name) {
+				leafFolderID = f.ID
+				leafProjectID = f.ProjectID
+				found = true
 				break
 			}
 		}
+		if !found {
+			created, err := e.folders.Create(ctx, name, parentID)
+			if err != nil {
+				return 0, fmt.Errorf("creating folder %q: %w", name, err)
+			}
+			leafFolderID = created.ID
+			leafProjectID = created.ProjectID
+			e.foldersCreated = append(e.foldersCreated, FolderCreated{
+				ServerPath: strings.Join(parts[:i+1], "/"),
+				FolderID:   leafFolderID,
+				ProjectID:  leafProjectID,
+			})
+			e.invalidateListCacheFor(parentID)
+		}
+		idCopy := leafFolderID
+		parentID = &idCopy
 	}
+
+	// Write-through cache for the leaf IDs, mirroring resolveAndCache.
+	e.writeCachedIDs(serverPath, leafFolderID, leafProjectID)
 	if e.projectRoot != "" && e.config != nil {
 		if err := config.Save(config.ProjectConfigPath(e.projectRoot), e.config); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: could not persist folder_id cache: %v\n", err)
 		}
 	}
-	return id, nil
+	return leafFolderID, nil
+}
+
+// resolveAndCache walks the folder hierarchy to resolve serverPath and
+// persists both folder_id AND project_id to the matching [[sync]]
+// entry in wk.toml. project_id is zero for plain folders and populated
+// for top-level projects (used by DELETE /projects/{project_id}).
+// Cache write failures are logged but non-fatal — the ID is still returned.
+func (e *SyncEngine) resolveAndCache(ctx context.Context, serverPath string) (int, error) {
+	f, err := e.resolveFolder(ctx, serverPath)
+	if err != nil {
+		return 0, err
+	}
+	if f == nil {
+		return 0, nil
+	}
+	e.writeCachedIDs(serverPath, f.ID, f.ProjectID)
+	if e.projectRoot != "" && e.config != nil {
+		if err := config.Save(config.ProjectConfigPath(e.projectRoot), e.config); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not persist folder_id cache: %v\n", err)
+		}
+	}
+	return f.ID, nil
+}
+
+// writeCachedIDs updates both folder_id and project_id on the matching
+// [[sync]] entry in memory. Callers batch config.Save once per sweep.
+// projectID is set verbatim — zero for plain folders, non-zero for
+// projects — so stale project_id values do get cleared if the server
+// folder stopped being a project between syncs.
+func (e *SyncEngine) writeCachedIDs(serverPath string, folderID, projectID int) {
+	if e.config == nil {
+		return
+	}
+	for i := range e.config.Sync {
+		if e.config.Sync[i].ServerPath == serverPath {
+			e.config.Sync[i].FolderID = folderID
+			e.config.Sync[i].ProjectID = projectID
+			return
+		}
+	}
 }
 
 // invalidFolderCacheErr reports whether err indicates that a cached folder_id
@@ -94,33 +195,39 @@ func (e *SyncEngine) wrapFolderErr(err error, entry config.SyncEntry, origFolder
 	return fmt.Errorf("resolving folder %q: %w", entry.ServerPath, err)
 }
 
-// resolveFolderID walks the Workato folder hierarchy to find the folder
-// matching serverPath (e.g. "Recipes/Production/Integrations").
-// The special name "All projects" is treated as the implicit workspace root
-// and stripped from the path before resolution.
-func (e *SyncEngine) resolveFolderID(ctx context.Context, serverPath string) (int, error) {
+// resolveFolder walks the Workato folder hierarchy to find the folder
+// matching serverPath (e.g. "Recipes/Production/Integrations") and
+// returns the full leaf Folder. The "All projects" prefix is treated
+// as the implicit workspace root and stripped before resolution; when
+// the path resolves to the root itself, returns (nil, nil).
+//
+// Callers that only need the folder_id wrap this via resolveFolderID;
+// those that need project_id (e.g. wk.toml cache writes) take the
+// full Folder.
+func (e *SyncEngine) resolveFolder(ctx context.Context, serverPath string) (*api.Folder, error) {
 	parts := strings.Split(strings.Trim(serverPath, "/"), "/")
 	if len(parts) == 0 || parts[0] == "" {
-		return 0, fmt.Errorf("empty server path")
+		return nil, fmt.Errorf("empty server path")
 	}
 
-	// Strip the implicit root folder if present.
 	if strings.EqualFold(parts[0], implicitRootFolder) {
 		parts = parts[1:]
 	}
 	if len(parts) == 0 {
-		return 0, nil
+		return nil, nil
 	}
 
 	var parentID *int
+	var leaf api.Folder
 	for _, name := range parts {
 		folders, err := e.listFolders(ctx, parentID)
 		if err != nil {
-			return 0, fmt.Errorf("listing folders under %v: %w", parentID, err)
+			return nil, fmt.Errorf("listing folders under %v: %w", parentID, err)
 		}
 		found := false
 		for _, f := range folders {
 			if strings.EqualFold(f.Name, name) {
+				leaf = f
 				id := f.ID
 				parentID = &id
 				found = true
@@ -128,10 +235,23 @@ func (e *SyncEngine) resolveFolderID(ctx context.Context, serverPath string) (in
 			}
 		}
 		if !found {
-			return 0, fmt.Errorf("folder %q not found under parent %v: %w", name, parentID, errPathNotResolved)
+			return nil, fmt.Errorf("folder %q not found under parent %v: %w", name, parentID, errPathNotResolved)
 		}
 	}
-	return *parentID, nil
+	return &leaf, nil
+}
+
+// resolveFolderID is the int-only wrapper around resolveFolder for
+// callers that don't need the full folder metadata.
+func (e *SyncEngine) resolveFolderID(ctx context.Context, serverPath string) (int, error) {
+	f, err := e.resolveFolder(ctx, serverPath)
+	if err != nil {
+		return 0, err
+	}
+	if f == nil {
+		return 0, nil
+	}
+	return f.ID, nil
 }
 
 // waitForPackage polls the export status until the package is complete.

--- a/internal/sync/helpers_test.go
+++ b/internal/sync/helpers_test.go
@@ -30,6 +30,10 @@ func (m *mockFolderService) Delete(_ context.Context, _ int) error {
 	return nil
 }
 
+func (m *mockFolderService) DeleteProject(_ context.Context, _ int) error {
+	return nil
+}
+
 func newTestEngine(folders map[int][]api.Folder) *SyncEngine {
 	return &SyncEngine{
 		folders: &mockFolderService{folders: folders},

--- a/internal/sync/push.go
+++ b/internal/sync/push.go
@@ -83,12 +83,18 @@ func (e *SyncEngine) Push(entry config.SyncEntry, dryRun bool, preserveState boo
 		return nil, e.wrapFolderErr(err, entry, entry.FolderID)
 	}
 
-	// Upload; invalidate cache and retry once on 404.
+	// Upload; invalidate cache and retry once on 404. The retry predicate
+	// checks the fresh folderID (not entry.FolderID) because the entry
+	// comes in by value — when folderIDForEntry freshly resolves or
+	// creates a folder, the updated ID lives on e.config.Sync[i] and
+	// on folderID, not on the local copy. Using entry.FolderID here
+	// would silently skip the retry for any just-resolved entry (and
+	// the create branch makes this case common enough to matter).
 	origFolderID := folderID
 	retried := false
 	restartRecipes := preserveState
 	importID, err := e.packages.Import(ctx, folderID, zipData, restartRecipes)
-	if err != nil && entry.FolderID != 0 && invalidFolderCacheErr(err) {
+	if err != nil && folderID != 0 && invalidFolderCacheErr(err) {
 		if fresh, rerr := e.resolveAndCache(ctx, entry.ServerPath); rerr == nil {
 			folderID = fresh
 			retried = true

--- a/internal/sync/refresh.go
+++ b/internal/sync/refresh.go
@@ -43,12 +43,15 @@ const (
 // ServerPath / LocalPath come from the incoming entry; FolderID is
 // either the resolved ID (found / current / repaired) or the cached ID
 // from before classification (not-found, so the developer can still
-// see what the local wk.toml had). Message carries a human detail
-// string for repaired / not-found; empty for found / current.
+// see what the local wk.toml had). ProjectID mirrors the same policy
+// for the distinct project identifier (populated when the folder is a
+// project, zero otherwise). Message carries a human detail string for
+// repaired / not-found; empty for found / current.
 type RefreshResult struct {
 	ServerPath string       `json:"server_path"`
 	LocalPath  string       `json:"local_path"`
 	FolderID   int          `json:"folder_id,omitempty"`
+	ProjectID  int          `json:"project_id,omitempty"`
 	State      RefreshState `json:"state"`
 	Message    string       `json:"message,omitempty"`
 }
@@ -72,9 +75,10 @@ func (e *SyncEngine) ClassifyEntry(ctx context.Context, entry config.SyncEntry) 
 		ServerPath: entry.ServerPath,
 		LocalPath:  entry.LocalPath,
 		FolderID:   entry.FolderID,
+		ProjectID:  entry.ProjectID,
 	}
 
-	id, err := e.resolveFolderID(ctx, entry.ServerPath)
+	f, err := e.resolveFolder(ctx, entry.ServerPath)
 	if err != nil {
 		if !errors.Is(err, errPathNotResolved) {
 			return RefreshResult{}, fmt.Errorf("resolving %q: %w", entry.ServerPath, err)
@@ -87,35 +91,34 @@ func (e *SyncEngine) ClassifyEntry(ctx context.Context, entry config.SyncEntry) 
 		}
 		return result, nil
 	}
-
-	if entry.FolderID == 0 {
-		result.State = RefreshStateFound
-		result.FolderID = id
-		e.writeCachedFolderID(entry.ServerPath, id)
-		return result, nil
-	}
-	if entry.FolderID == id {
+	if f == nil {
 		result.State = RefreshStateCurrent
 		return result, nil
 	}
 
-	result.State = RefreshStateRepaired
-	result.FolderID = id
-	result.Message = fmt.Sprintf("cached folder_id changed from %d to %d", entry.FolderID, id)
-	e.writeCachedFolderID(entry.ServerPath, id)
-	return result, nil
-}
-
-// writeCachedFolderID updates the in-memory config slot for the
-// matching [[sync]] entry. Callers batch config.Save once per sweep.
-func (e *SyncEngine) writeCachedFolderID(serverPath string, id int) {
-	if e.config == nil {
-		return
+	if entry.FolderID == 0 {
+		result.State = RefreshStateFound
+		result.FolderID = f.ID
+		result.ProjectID = f.ProjectID
+		e.writeCachedIDs(entry.ServerPath, f.ID, f.ProjectID)
+		return result, nil
 	}
-	for i := range e.config.Sync {
-		if e.config.Sync[i].ServerPath == serverPath {
-			e.config.Sync[i].FolderID = id
-			return
+	if entry.FolderID == f.ID {
+		result.State = RefreshStateCurrent
+		// Even on current, keep project_id in sync — the server folder
+		// may have switched is_project status without changing its id
+		// (edge but possible). Cheap update; keeps cache truthful.
+		if entry.ProjectID != f.ProjectID {
+			result.ProjectID = f.ProjectID
+			e.writeCachedIDs(entry.ServerPath, f.ID, f.ProjectID)
 		}
+		return result, nil
 	}
+
+	result.State = RefreshStateRepaired
+	result.FolderID = f.ID
+	result.ProjectID = f.ProjectID
+	result.Message = fmt.Sprintf("cached folder_id changed from %d to %d", entry.FolderID, f.ID)
+	e.writeCachedIDs(entry.ServerPath, f.ID, f.ProjectID)
+	return result, nil
 }

--- a/internal/sync/refresh_test.go
+++ b/internal/sync/refresh_test.go
@@ -40,6 +40,10 @@ func (m *refreshMockFolders) Delete(_ context.Context, _ int) error {
 	return nil
 }
 
+func (m *refreshMockFolders) DeleteProject(_ context.Context, _ int) error {
+	return nil
+}
+
 func newRefreshEngine(cfg *config.Config, folders *refreshMockFolders) *SyncEngine {
 	return &SyncEngine{
 		config:  cfg,
@@ -275,6 +279,63 @@ func TestClassifyEntry_ListCacheDisabledCallsEachTime(t *testing.T) {
 	}
 	if folders.listCalls != 2 {
 		t.Errorf("listCalls = %d, want 2 (cache disabled → one List per entry)", folders.listCalls)
+	}
+}
+
+// TestClassifyEntry_CapturesProjectID: when a `found` classification
+// populates the cache, project_id must land alongside folder_id in
+// wk.toml. wk folders delete depends on project_id being present.
+func TestClassifyEntry_CapturesProjectID(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "MyProject"}},
+	}
+	engine := newRefreshEngine(cfg, &refreshMockFolders{
+		list: map[int][]api.Folder{
+			-1: {{ID: 100, Name: "MyProject", IsProject: true, ProjectID: 9001}},
+		},
+	})
+
+	result, err := engine.ClassifyEntry(context.Background(), cfg.Sync[0])
+	if err != nil {
+		t.Fatalf("ClassifyEntry: %v", err)
+	}
+	if result.State != RefreshStateFound {
+		t.Errorf("state = %q, want %q", result.State, RefreshStateFound)
+	}
+	if result.FolderID != 100 {
+		t.Errorf("result.FolderID = %d, want 100", result.FolderID)
+	}
+	if result.ProjectID != 9001 {
+		t.Errorf("result.ProjectID = %d, want 9001", result.ProjectID)
+	}
+	if cfg.Sync[0].FolderID != 100 || cfg.Sync[0].ProjectID != 9001 {
+		t.Errorf("cfg.Sync[0] = {%d, %d}, want {100, 9001}", cfg.Sync[0].FolderID, cfg.Sync[0].ProjectID)
+	}
+}
+
+// TestClassifyEntry_CurrentRefreshesProjectIDOnChange: even when the
+// folder_id is unchanged, a stale project_id must be refreshed. This
+// case is rare but possible — the server can flip is_project on a
+// folder without changing its id.
+func TestClassifyEntry_CurrentRefreshesProjectIDOnChange(t *testing.T) {
+	cfg := &config.Config{
+		Sync: []config.SyncEntry{{ServerPath: "MyProject", FolderID: 100, ProjectID: 0}},
+	}
+	engine := newRefreshEngine(cfg, &refreshMockFolders{
+		list: map[int][]api.Folder{
+			-1: {{ID: 100, Name: "MyProject", IsProject: true, ProjectID: 9001}},
+		},
+	})
+
+	result, err := engine.ClassifyEntry(context.Background(), cfg.Sync[0])
+	if err != nil {
+		t.Fatalf("ClassifyEntry: %v", err)
+	}
+	if result.State != RefreshStateCurrent {
+		t.Errorf("state = %q, want %q", result.State, RefreshStateCurrent)
+	}
+	if cfg.Sync[0].ProjectID != 9001 {
+		t.Errorf("cfg.Sync[0].ProjectID = %d, want 9001 (refreshed even on current)", cfg.Sync[0].ProjectID)
 	}
 }
 


### PR DESCRIPTION
Adding a "create on demand" push behavior to support better greenfield project ergonomics. Adds de-dupe guard as well. Expanding wk folders delete (manual testing bug discovery) to adequately support both folder and project folder types.