### PR TITLE
Cleaning up docs, tightening help text, revising ADR-007 post delivery

### DIFF
--- a/docs/ADR-005-project-scaffolding.md
+++ b/docs/ADR-005-project-scaffolding.md
@@ -1,12 +1,14 @@
 # ADR-005: Project Scaffolding — Container Folder, `.wk/` Directory, and Ignore Semantics
 
-**Status:** Accepted
+**Status:** Accepted (Issue #29 follow-up superseded by ADR-007)
 **Date:** March 26, 2026 (revised April 8, 2026; implemented April 17, 2026)
 **Author:** Zayne Turner
 **Deciders:** DevRel Engineering
-**References:** ADR-001 (Foundational Architecture), ADR-002 (Sync Engine), Tester Feedback (Greenfield Project Setup)
+**References:** ADR-001 (Foundational Architecture), ADR-002 (Sync Engine), ADR-007 (Greenfield Onboarding), Tester Feedback (Greenfield Project Setup)
 
 > This revision supersedes the April 1, 2026 amendment on sidecar metadata location by integrating those decisions into the main body. It also adds decisions for folder ID caching, init overwrite behavior, and `.wkignore` support.
+>
+> **Partial supersession by ADR-007 (April 2026):** the single-entry init flag surface described here (`--server-path` / `--local-path`) was removed in ADR-007 in favor of `--project` / `--projects-dir` / `--sync`. `wk init --overwrite` was changed from preserving existing `[[sync]]` entries to replacing them, and the Issue #29 follow-up (deferred incremental sync-entry management) was closed by ADR-007 with the top-level `wk sync add/list/refresh/remove` command group. References to `--server-path` / `--local-path` / `wk project sync` in this ADR's text reflect the historical state at the time of writing; the current flag surface lives in ADR-007.
 
 ---
 

--- a/docs/ADR-007-greenfield-onboarding.md
+++ b/docs/ADR-007-greenfield-onboarding.md
@@ -544,6 +544,32 @@ Under `--json`, creation events are included as a structured array in the push r
 
 ---
 
+## Post-Implementation Notes
+
+These record divergences from the original spec that came up during implementation. The Decision text above is preserved as the design intent; the notes below are the as-built reality.
+
+- **Decision 5 rule 1 — exact duplicates are errors, not silent dedup.** The original rule said identical `(server_path, local_path)` tuples within one invocation dedup to one entry. Implementation errors instead: a developer who typed `--project foo --project foo` almost certainly made a typo, and silent dedup hides it. The conflict-rule machinery now flags both duplicates and same-server-path-different-local-path with distinct error messages. Against existing `wk.toml` entries, exact matches still silently skip per Decision 8 rule 3.
+
+- **Decision 7 — `--overwrite` replaces rather than preserves.** Described in the Decision text, but worth calling out: the Issue #29 preservation workaround (keeping hand-edited `[[sync]]` entries through `--overwrite`) was obsoleted by the new flag surface. `--overwrite` now replaces the wk.toml in full. For incremental edits, use `wk sync add` / `wk sync remove`.
+
+- **Decision 11 — four states, not four-plus-API-validation.** The original spec used `GET /folders/{id}` to distinguish `current` (200) from `stale` (404) for already-cached entries. That endpoint does not exist in the Workato API. Implementation validates cached IDs by walking the hierarchy via `List` and comparing the resolved leaf ID against the cached value. The four states became:
+  - `found` — no cache, walk succeeded (first-time resolve)
+  - `current` — cache matches walk result
+  - `repaired` — cache present but walk returned a different id; auto-healed (a case the original `Get`-based design couldn't see)
+  - `not-found` — walk failed. Cached entries retain their pre-classify `folder_id` in the output so "used to work" vs "never worked" stays visible without a fifth state.
+
+- **Decisions 7, 12, 14 — project_id alongside folder_id.** The Workato folders list returns both `is_project` and a distinct `project_id` when the folder is a top-level project. `DELETE /projects/{project_id}` requires the project id (not the folder id), so `SyncEntry` gained a `ProjectID` field stored alongside `FolderID`. Every cache-fill path (`--verify`, `wk sync refresh`, push's create branch) captures both, and `wk folders delete` routes by `IsProject`, passing `project_id` when true.
+
+- **`--no-input` promoted to a root persistent flag.** Originally init-local, but the contract "commands that don't prompt should still accept `--no-input` as a no-op" is cleanest as a root persistent flag. Scripts can pass `--no-input` uniformly without learning which subcommands honor it.
+
+- **Folder-list memoization during `wk sync refresh`.** N entries sharing a workspace would refetch the same folder list N times. `SyncEngine.EnableFolderListCache()` opts into per-parent memoization for the duration of a sweep; pull/push/status keep the cache disabled so they always see fresh server state.
+
+- **Pre-existing retry-predicate fix.** `push.go`'s cache-invalidation retry originally gated on the pass-by-value `entry.FolderID`, which stayed zero when a folder was freshly resolved or created mid-push. Fixed alongside the create branch (Decision 12): the retry now checks the returned `folderID` instead.
+
+- **`wk project` namespace deleted.** With the sync subtree moved out, nothing remained under `wk project`. The empty parent namespace was removed rather than kept as a placeholder; a future `wk project rm` / `wk project rename` can reintroduce it when there's a concrete command to register.
+
+---
+
 ## Action Items
 
 1. [ ] Extract shared flag-binding and entry-assembly helpers from `wk init` into `internal/commands/sync_flags.go` (or similar) so `wk sync add` can reuse them without duplication

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -80,8 +80,8 @@ $WK plugins list
 TESTDIR="$(mktemp -d)"
 cd "$TESTDIR"
 
-$WK init --name my-test --workspace dev --server-path "All projects/Test" --local-path "./recipes"
-cat wk.toml
+$WK init --name my-test --profile dev --sync "All projects/Test:./recipes"
+cat my-test/.wk/wk.toml
 # Expected: valid wk.toml with sync entry
 
 $WK status
@@ -227,12 +227,12 @@ TESTDIR=$(mktemp -d)
 
 ```sh
 cd "$TESTDIR"
-wk init --name test-project --workspace dev --server-path "All projects/Test" --local-path "./recipes"
+wk init --name test-project --profile dev --sync "All projects/Test:./recipes"
 ```
 
-Expected: prints success message. A `wk.toml` file exists with:
+Expected: prints success message. A `test-project/.wk/wk.toml` file exists with:
 - `name = 'test-project'`
-- `workspace = 'dev'`
+- `profile = 'dev'`
 - A `[[sync]]` block with `server_path` and `local_path`
 
 **Init should fail if wk.toml already exists:**
@@ -497,7 +497,7 @@ SYNCDIR=$(mktemp -d)
 cd "$SYNCDIR"
 
 # Create a project pointing at a real folder
-wk init --name sync-test --workspace test-live --server-path "$TEST_SERVER_PATH" --local-path "./assets"
+wk init --name sync-test --profile test-live --sync "$TEST_SERVER_PATH:./assets"
 ```
 
 **Pull:**

--- a/internal/commands/init.go
+++ b/internal/commands/init.go
@@ -366,7 +366,7 @@ wk sync add/remove for incremental edits.`,
 	// break -p on `wk init`.
 	BindSyncEntryFlags(cmd, &syncFlags)
 	cmd.Flags().BoolVar(&flagVerify, "verify", false,
-		"Validate every declared server-path against Workato and cache the resolved folder_id in wk.toml (ADR-007 Decision 7)")
+		"Validate every declared server-path against Workato and cache resolved IDs in wk.toml")
 	cmd.Flags().BoolVarP(&flagOverwrite, "overwrite", "o", false, "Overwrite an existing project config without prompting (non-interactive mode)")
 
 	return cmd

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -107,7 +107,8 @@ func newPushCmd() *cobra.Command {
 		Long: `Upload modified local assets to the Workato workspace.
 
 When an entry's server_path does not yet exist on the workspace, push
-creates it (ADR-007 Decision 12). Gating:
+creates it on first call so 'wk init' + 'wk push' works end-to-end
+without a manual folder step. Gating:
 
   --no-create        Disable auto-create entirely. Missing folders error.
                      Recommended for CI / production deploys.
@@ -116,7 +117,8 @@ creates it (ADR-007 Decision 12). Gating:
 
 Both gates are mutually exclusive. By default, a bare server_path
 (no slashes) is auto-created on first push; a nested path that does
-not resolve errors unless --create-path is passed.`,
+not resolve errors unless --create-path is passed. Created folders are
+reported on stderr (or as folders_created in --json output).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if flagNoCreate && flagCreatePath {
 				return fmt.Errorf("--no-create and --create-path are mutually exclusive")
@@ -215,7 +217,7 @@ not resolve errors unless --create-path is passed.`,
 	cmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "Show what would be pushed without uploading")
 	cmd.Flags().BoolVar(&flagPreserveState, "preserve-state", true, "Preserve recipe active state on import")
 	cmd.Flags().BoolVar(&flagSkipHooks, "skip-hooks", false, "Skip plugin pre-push hooks")
-	cmd.Flags().BoolVar(&flagNoCreate, "no-create", false, "Error instead of auto-creating missing server folders (ADR-007 Decision 13)")
+	cmd.Flags().BoolVar(&flagNoCreate, "no-create", false, "Error instead of auto-creating missing server folders")
 	cmd.Flags().BoolVar(&flagCreatePath, "create-path", false, "Create every missing segment of a nested server_path (not just bare names)")
 
 	return cmd

--- a/internal/commands/sync_add.go
+++ b/internal/commands/sync_add.go
@@ -111,6 +111,6 @@ within one invocation are flagged as errors.`,
 	}
 	BindSyncEntryFlags(cmd, &syncFlags)
 	cmd.Flags().BoolVar(&flagVerify, "verify", false,
-		"Validate every declared server-path against Workato and cache the resolved folder_id (ADR-007 Decision 7)")
+		"Validate every declared server-path against Workato and cache resolved IDs in wk.toml")
 	return cmd
 }


### PR DESCRIPTION
Cleans up testing.md, some ADR cross-refs, adding post-implementation notes to ADR-007. Improving help text for new commands.