### PR TITLE
adding symlink to support plugin binary and files at $PATH

### DIFF
--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -40,6 +40,10 @@ func newPluginsInstallCmd() *cobra.Command {
 				if lookErr != nil {
 					return fmt.Errorf("plugin %q not found on $PATH; to install from a local directory, use: wk plugins install ./%s", source, source)
 				}
+				binPath, err = filepath.EvalSymlinks(binPath)
+				if err != nil {
+					return fmt.Errorf("resolving symlink: %w", err)
+				}
 				source, err = filepath.Abs(filepath.Dir(binPath))
 			} else {
 				source, err = filepath.Abs(source)


### PR DESCRIPTION
Still working on #51, addressing install state reality of plugin artifacts at $path