### PR TITLE
Zt/tester feedback

### DIFF
--- a/internal/api/api_endpoints.go
+++ b/internal/api/api_endpoints.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -33,6 +34,21 @@ func (s *apiEndpointService) List(ctx context.Context, collectionID *int, opts *
 		return nil, err
 	}
 	return result, nil
+}
+
+func (s *apiEndpointService) Create(ctx context.Context, collectionID int, data []byte) (*APIEndpoint, error) {
+	var body map[string]any
+	if err := json.Unmarshal(data, &body); err != nil {
+		return nil, fmt.Errorf("invalid endpoint JSON: %w", err)
+	}
+	var ep APIEndpoint
+	if err := s.client.do(ctx, "POST", fmt.Sprintf("/api_collections/%d/api_endpoints", collectionID), body, &ep); err != nil {
+		return nil, err
+	}
+	if ep.RecipeID == 0 && ep.FlowID != 0 {
+		ep.RecipeID = ep.FlowID
+	}
+	return &ep, nil
 }
 
 func (s *apiEndpointService) Enable(ctx context.Context, id int) error {

--- a/internal/api/api_endpoints_test.go
+++ b/internal/api/api_endpoints_test.go
@@ -43,6 +43,44 @@ func TestAPIEndpointService_List(t *testing.T) {
 	}
 }
 
+func TestAPIEndpointService_Create(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api_collections/5/api_endpoints" {
+			t.Errorf("path = %s, want /api_collections/5/api_endpoints", r.URL.Path)
+		}
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["name"] != "Create User" {
+			t.Errorf("name = %v, want Create User", body["name"])
+		}
+		if body["flow_id"] != float64(42) {
+			t.Errorf("flow_id = %v, want 42", body["flow_id"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":99,"name":"Create User","api_collection_id":5,"active":false,"method":"POST","path":"/users","flow_id":42}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	data := []byte(`{"name":"Create User","method":"POST","path":"/users","flow_id":42}`)
+	ep, err := client.APIEndpoints().Create(context.Background(), 5, data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ep.ID != 99 {
+		t.Errorf("ID = %d, want 99", ep.ID)
+	}
+	if ep.RecipeID != 42 {
+		t.Errorf("RecipeID = %d, want 42 (backfilled from flow_id)", ep.RecipeID)
+	}
+	if ep.Method != "POST" || ep.Path != "/users" {
+		t.Errorf("Method/Path = %s %s, want POST /users", ep.Method, ep.Path)
+	}
+}
+
 func TestAPIEndpointService_Enable(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "PUT" {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -13,6 +13,7 @@ type RecipeService interface {
 	Update(ctx context.Context, id int, data []byte) error
 	Delete(ctx context.Context, id int) error
 	ListJobs(ctx context.Context, recipeID int, opts *JobListOptions) ([]Job, error)
+	GetJob(ctx context.Context, recipeID int, jobID string) (*JobDetail, error)
 	Copy(ctx context.Context, recipeID, folderID int) (*Recipe, error)
 	Connect(ctx context.Context, recipeID int, adapterName string, connectionID int) error
 	ListVersions(ctx context.Context, recipeID, page, perPage int) ([]RecipeVersion, error)
@@ -86,6 +87,7 @@ type APICollectionService interface {
 // APIEndpointService defines operations on API endpoints.
 type APIEndpointService interface {
 	List(ctx context.Context, collectionID *int, opts *PaginationOptions) ([]APIEndpoint, error)
+	Create(ctx context.Context, collectionID int, data []byte) (*APIEndpoint, error)
 	Enable(ctx context.Context, id int) error
 	Disable(ctx context.Context, id int) error
 }
@@ -93,7 +95,7 @@ type APIEndpointService interface {
 // SkillService defines operations on agentic skills.
 type SkillService interface {
 	List(ctx context.Context, opts *PaginationOptions) ([]Skill, error)
-	Get(ctx context.Context, id int) (*Skill, error)
+	Get(ctx context.Context, id string) (*Skill, error)
 	Create(ctx context.Context, recipeID int) (*Skill, error)
 }
 

--- a/internal/api/recipes.go
+++ b/internal/api/recipes.go
@@ -100,7 +100,8 @@ func (s *recipeService) Delete(ctx context.Context, id int) error {
 }
 
 // decodeAndResolve unmarshals recipe JSON, resolves any connection reference
-// objects in config to integer IDs, then stringifies code/config for the API.
+// objects in config to integer IDs, backfills missing "name" fields from
+// "provider", then stringifies code/config for the API.
 func (s *recipeService) decodeAndResolve(ctx context.Context, data []byte) (map[string]any, error) {
 	var body map[string]any
 	if err := json.Unmarshal(data, &body); err != nil {
@@ -110,6 +111,7 @@ func (s *recipeService) decodeAndResolve(ctx context.Context, data []byte) (map[
 	if err := s.resolveConfigConnections(ctx, body); err != nil {
 		return nil, err
 	}
+	backfillConfigNames(body)
 
 	for _, key := range []string{"code", "config"} {
 		v, ok := body[key]
@@ -194,6 +196,33 @@ func (s *recipeService) resolveConfigConnections(ctx context.Context, body map[s
 	return nil
 }
 
+// backfillConfigNames ensures every config entry has a "name" field. The
+// Workato platform requires it to wire adapters on activation; exports always
+// set name == provider, but hand-crafted or ZIP-extracted JSON may omit it,
+// causing a silent activation failure.
+func backfillConfigNames(body map[string]any) {
+	configVal, ok := body["config"]
+	if !ok {
+		return
+	}
+	configSlice, ok := configVal.([]any)
+	if !ok {
+		return
+	}
+	for _, entry := range configSlice {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, hasName := entryMap["name"]; hasName {
+			continue
+		}
+		if provider, ok := entryMap["provider"].(string); ok && provider != "" {
+			entryMap["name"] = provider
+		}
+	}
+}
+
 func (s *recipeService) ListJobs(ctx context.Context, recipeID int, opts *JobListOptions) ([]Job, error) {
 	params := url.Values{}
 	if opts != nil {
@@ -213,6 +242,14 @@ func (s *recipeService) ListJobs(ctx context.Context, recipeID int, opts *JobLis
 		return nil, err
 	}
 	return result.Items, nil
+}
+
+func (s *recipeService) GetJob(ctx context.Context, recipeID int, jobID string) (*JobDetail, error) {
+	var detail JobDetail
+	if err := s.client.do(ctx, "GET", fmt.Sprintf("/recipes/%d/jobs/%s", recipeID, url.PathEscape(jobID)), nil, &detail); err != nil {
+		return nil, err
+	}
+	return &detail, nil
 }
 
 func (s *recipeService) Copy(ctx context.Context, recipeID, folderID int) (*Recipe, error) {

--- a/internal/api/recipes_test.go
+++ b/internal/api/recipes_test.go
@@ -21,7 +21,7 @@ func TestRecipeService_ListJobs(t *testing.T) {
 			t.Errorf("status = %q, want succeeded", s)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(ListResult[Job]{Items: []Job{{ID: 1, RecipeID: 42, Status: "succeeded"}}})
+		json.NewEncoder(w).Encode(ListResult[Job]{Items: []Job{{ID: "j-1", RecipeID: 42, Status: "succeeded"}}})
 	}))
 	defer srv.Close()
 
@@ -32,6 +32,50 @@ func TestRecipeService_ListJobs(t *testing.T) {
 	}
 	if len(jobs) != 1 || jobs[0].Status != "succeeded" {
 		t.Errorf("got %+v, want 1 succeeded job", jobs)
+	}
+}
+
+func TestRecipeService_GetJob(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/recipes/42/jobs/j-abc123" {
+			t.Errorf("path = %s, want /recipes/42/jobs/j-abc123", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		resp := `{
+			"id": "j-abc123", "recipe_id": 42, "status": "failed",
+			"is_error": true, "error": "Connection timeout",
+			"handle": "j-abc123",
+			"lines": [
+				{"recipe_line_number": 1, "adapter_name": "rest", "adapter_operation": "make_request_v2"},
+				{"recipe_line_number": 2, "adapter_name": "logger", "adapter_operation": "log_message"}
+			]
+		}`
+		w.Write([]byte(resp))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	detail, err := client.Recipes().GetJob(context.Background(), 42, "j-abc123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if detail.Status != "failed" {
+		t.Errorf("status = %q, want failed", detail.Status)
+	}
+	if detail.Error == nil || *detail.Error != "Connection timeout" {
+		t.Errorf("error = %v, want 'Connection timeout'", detail.Error)
+	}
+	if detail.Handle != "j-abc123" {
+		t.Errorf("handle = %q, want j-abc123", detail.Handle)
+	}
+	if len(detail.Lines) != 2 {
+		t.Fatalf("lines count = %d, want 2", len(detail.Lines))
+	}
+	if detail.Lines[0].AdapterName != "rest" {
+		t.Errorf("lines[0].adapter_name = %q, want rest", detail.Lines[0].AdapterName)
 	}
 }
 
@@ -172,6 +216,85 @@ func TestRecipeService_Update_StringifiesCodeAndConfig(t *testing.T) {
 	}
 	if s, ok := captured["config"].(string); !ok || s != `[{"k":"v"}]` {
 		t.Errorf("config not stringified; got %T %v", captured["config"], captured["config"])
+	}
+}
+
+func TestRecipeService_Import_BackfillsConfigName(t *testing.T) {
+	var captured map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/recipes":
+			json.NewDecoder(r.Body).Decode(&captured)
+			w.Write([]byte(`{"success":true,"id":1}`))
+		case r.Method == "GET" && r.URL.Path == "/recipes/1":
+			json.NewEncoder(w).Encode(Recipe{ID: 1, Name: "test", FolderID: 10})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	// Config entry missing "name" — should be backfilled from "provider".
+	body := []byte(`{"name":"test","code":{},"config":[{"keyword":"application","provider":"salesforce","account_id":123}]}`)
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	_, err := client.Recipes().Import(context.Background(), 10, body)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	configStr, ok := captured["config"].(string)
+	if !ok {
+		t.Fatalf("config not stringified; got %T", captured["config"])
+	}
+	var config []map[string]any
+	if err := json.Unmarshal([]byte(configStr), &config); err != nil {
+		t.Fatalf("parsing config: %v", err)
+	}
+	if len(config) != 1 {
+		t.Fatalf("config entries = %d, want 1", len(config))
+	}
+	if config[0]["name"] != "salesforce" {
+		t.Errorf("name = %v, want salesforce (backfilled from provider)", config[0]["name"])
+	}
+}
+
+func TestRecipeService_Import_PreservesExistingConfigName(t *testing.T) {
+	var captured map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/recipes":
+			json.NewDecoder(r.Body).Decode(&captured)
+			w.Write([]byte(`{"success":true,"id":1}`))
+		case r.Method == "GET" && r.URL.Path == "/recipes/1":
+			json.NewEncoder(w).Encode(Recipe{ID: 1, Name: "test", FolderID: 10})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	// Config entry already has "name" — should not be overwritten.
+	body := []byte(`{"name":"test","code":{},"config":[{"keyword":"application","provider":"salesforce","name":"salesforce","account_id":123}]}`)
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	_, err := client.Recipes().Import(context.Background(), 10, body)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+
+	configStr, ok := captured["config"].(string)
+	if !ok {
+		t.Fatalf("config not stringified; got %T", captured["config"])
+	}
+	var config []map[string]any
+	if err := json.Unmarshal([]byte(configStr), &config); err != nil {
+		t.Fatalf("parsing config: %v", err)
+	}
+	if config[0]["name"] != "salesforce" {
+		t.Errorf("name = %v, want salesforce (preserved)", config[0]["name"])
 	}
 }
 

--- a/internal/api/skills.go
+++ b/internal/api/skills.go
@@ -11,9 +11,12 @@ type skillService struct {
 	client *HTTPClient
 }
 
-// skillListResponse wraps the paginated response from GET /agentic/skills.
 type skillListResponse struct {
 	Data []Skill `json:"data"`
+}
+
+type skillDataResponse struct {
+	Data Skill `json:"data"`
 }
 
 func (s *skillService) List(ctx context.Context, opts *PaginationOptions) ([]Skill, error) {
@@ -34,24 +37,35 @@ func (s *skillService) List(ctx context.Context, opts *PaginationOptions) ([]Ski
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
+	for i := range result.Data {
+		backfillSkillRecipeID(&result.Data[i])
+	}
 	return result.Data, nil
 }
 
-func (s *skillService) Get(ctx context.Context, id int) (*Skill, error) {
-	var skill Skill
-	if err := s.client.do(ctx, "GET", fmt.Sprintf("/agentic/skills/%d", id), nil, &skill); err != nil {
+func (s *skillService) Get(ctx context.Context, id string) (*Skill, error) {
+	var result skillDataResponse
+	if err := s.client.do(ctx, "GET", fmt.Sprintf("/agentic/skills/%s", id), nil, &result); err != nil {
 		return nil, err
 	}
-	return &skill, nil
+	backfillSkillRecipeID(&result.Data)
+	return &result.Data, nil
 }
 
 func (s *skillService) Create(ctx context.Context, recipeID int) (*Skill, error) {
 	body := map[string]any{
 		"recipe_id": recipeID,
 	}
-	var skill Skill
-	if err := s.client.do(ctx, "POST", "/agentic/skills", body, &skill); err != nil {
+	var result skillDataResponse
+	if err := s.client.do(ctx, "POST", "/agentic/skills", body, &result); err != nil {
 		return nil, err
 	}
-	return &skill, nil
+	backfillSkillRecipeID(&result.Data)
+	return &result.Data, nil
+}
+
+func backfillSkillRecipeID(s *Skill) {
+	if s.RecipeID == 0 && s.ProviderID != 0 {
+		s.RecipeID = s.ProviderID
+	}
 }

--- a/internal/api/skills_test.go
+++ b/internal/api/skills_test.go
@@ -17,9 +17,7 @@ func TestSkillService_List(t *testing.T) {
 			t.Errorf("path = %s, want /agentic/skills", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"data": []Skill{{ID: 1, Name: "my-skill", Description: "test skill", RecipeID: 100, FolderID: 10, ProjectID: 5}},
-		})
+		w.Write([]byte(`{"data":[{"id":"skl-001","name":"my-skill","description":"test skill","provider_id":100,"provider_type":"Recipe","folder_id":10,"project_id":5,"running":true,"genies_count":2}]}`))
 	}))
 	defer srv.Close()
 
@@ -32,17 +30,29 @@ func TestSkillService_List(t *testing.T) {
 		t.Errorf("got %+v, want 1 skill named my-skill", skills)
 	}
 	s := skills[0]
+	if s.ID != "skl-001" {
+		t.Errorf("ID = %q, want skl-001", s.ID)
+	}
 	if s.Description != "test skill" {
 		t.Errorf("Description = %q, want %q", s.Description, "test skill")
 	}
+	if s.ProviderID != 100 {
+		t.Errorf("ProviderID = %d, want 100", s.ProviderID)
+	}
 	if s.RecipeID != 100 {
-		t.Errorf("RecipeID = %d, want 100", s.RecipeID)
+		t.Errorf("RecipeID = %d, want 100 (backfilled from ProviderID)", s.RecipeID)
 	}
 	if s.FolderID != 10 {
 		t.Errorf("FolderID = %d, want 10", s.FolderID)
 	}
 	if s.ProjectID != 5 {
 		t.Errorf("ProjectID = %d, want 5", s.ProjectID)
+	}
+	if !s.Running {
+		t.Errorf("Running = false, want true")
+	}
+	if s.GeniesCount != 2 {
+		t.Errorf("GeniesCount = %d, want 2", s.GeniesCount)
 	}
 }
 
@@ -51,24 +61,27 @@ func TestSkillService_Get(t *testing.T) {
 		if r.Method != "GET" {
 			t.Errorf("method = %s, want GET", r.Method)
 		}
-		if r.URL.Path != "/agentic/skills/42" {
-			t.Errorf("path = %s, want /agentic/skills/42", r.URL.Path)
+		if r.URL.Path != "/agentic/skills/skl-042" {
+			t.Errorf("path = %s, want /agentic/skills/skl-042", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(Skill{ID: 42, Name: "lookup-skill", RecipeID: 200, FolderID: 20, ProjectID: 8})
+		w.Write([]byte(`{"data":{"id":"skl-042","name":"lookup-skill","provider_id":200,"folder_id":20,"project_id":8,"running":false,"genies_count":0}}`))
 	}))
 	defer srv.Close()
 
 	client := NewHTTPClient(srv.URL, "test-token")
-	s, err := client.Skills().Get(context.Background(), 42)
+	s, err := client.Skills().Get(context.Background(), "skl-042")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if s.ID != 42 {
-		t.Errorf("ID = %d, want 42", s.ID)
+	if s.ID != "skl-042" {
+		t.Errorf("ID = %q, want skl-042", s.ID)
 	}
 	if s.Name != "lookup-skill" {
 		t.Errorf("Name = %q, want %q", s.Name, "lookup-skill")
+	}
+	if s.RecipeID != 200 {
+		t.Errorf("RecipeID = %d, want 200 (backfilled from ProviderID)", s.RecipeID)
 	}
 }
 
@@ -86,7 +99,7 @@ func TestSkillService_Create(t *testing.T) {
 			t.Errorf("recipe_id = %v, want 300", body["recipe_id"])
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(Skill{ID: 7, Name: "new-skill", RecipeID: 300, FolderID: 30, ProjectID: 12})
+		w.Write([]byte(`{"data":{"id":"skl-007","name":"new-skill","provider_id":300,"provider_type":"Recipe","folder_id":30,"project_id":12,"running":true,"genies_count":0}}`))
 	}))
 	defer srv.Close()
 
@@ -95,10 +108,13 @@ func TestSkillService_Create(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if s.ID != 7 {
-		t.Errorf("ID = %d, want 7", s.ID)
+	if s.ID != "skl-007" {
+		t.Errorf("ID = %q, want skl-007", s.ID)
 	}
 	if s.RecipeID != 300 {
-		t.Errorf("RecipeID = %d, want 300", s.RecipeID)
+		t.Errorf("RecipeID = %d, want 300 (backfilled from ProviderID)", s.RecipeID)
+	}
+	if s.ProviderType != "Recipe" {
+		t.Errorf("ProviderType = %q, want Recipe", s.ProviderType)
 	}
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -88,11 +88,47 @@ type PackageContent struct {
 	Type         string `json:"type"` // "recipe", "connection", etc.
 }
 
-// Job represents a recipe job execution.
+// Job represents a recipe job execution. Job IDs are strings
+// (e.g. "j-AJMfQh8c-hsCXcs"); recipe IDs are integers.
 type Job struct {
-	ID          int        `json:"id"`
-	RecipeID    int        `json:"recipe_id"`
-	Status      string     `json:"status"` // "succeeded", "failed", "pending"
+	ID              string     `json:"id"`
+	RecipeID        int        `json:"recipe_id"`
+	Status          string     `json:"status"` // "succeeded", "failed", "pending"
+	StartedAt       *time.Time `json:"started_at,omitempty"`
+	CompletedAt     *time.Time `json:"completed_at,omitempty"`
+	Title           string     `json:"title,omitempty"`
+	IsError         bool       `json:"is_error"`
+	Error           *string    `json:"error,omitempty"`
+	IsPollError     bool       `json:"is_poll_error"`
+	CallingRecipeID *int       `json:"calling_recipe_id,omitempty"`
+	CallingJobID    *string    `json:"calling_job_id,omitempty"`
+	RootRecipeID    *int       `json:"root_recipe_id,omitempty"`
+	RootJobID       *string    `json:"root_job_id,omitempty"`
+	MasterJobID     *string    `json:"master_job_id,omitempty"`
+}
+
+// JobDetail is the single-job response from GET /recipes/{id}/jobs/{job_id}.
+type JobDetail struct {
+	Job
+	Handle           string    `json:"handle,omitempty"`
+	IsRepeat         bool      `json:"is_repeat"`
+	IsTest           bool      `json:"is_test"`
+	IsTestCaseJob    bool      `json:"is_test_case_job"`
+	MasterJobHandle  string    `json:"master_job_handle,omitempty"`
+	CallingJobHandle string    `json:"calling_job_handle,omitempty"`
+	Lines            []JobLine `json:"lines,omitempty"`
+}
+
+// JobLine represents a single step in a job execution trace.
+type JobLine struct {
+	RecipeLineNumber int       `json:"recipe_line_number"`
+	AdapterName      string    `json:"adapter_name"`
+	AdapterOperation string    `json:"adapter_operation"`
+	LineStat         *LineStat `json:"line_stat,omitempty"`
+}
+
+// LineStat holds timing data for a job step.
+type LineStat struct {
 	StartedAt   *time.Time `json:"started_at,omitempty"`
 	CompletedAt *time.Time `json:"completed_at,omitempty"`
 }
@@ -136,7 +172,9 @@ type APICollection struct {
 	ProjectID   int    `json:"project_id"`
 }
 
-// APIEndpoint represents a Workato API endpoint.
+// APIEndpoint represents a Workato API endpoint. The create response returns
+// "flow_id" where the list response returns "recipe_id"; FlowID captures the
+// former so both paths decode cleanly.
 type APIEndpoint struct {
 	ID              int    `json:"id"`
 	Name            string `json:"name"`
@@ -145,16 +183,25 @@ type APIEndpoint struct {
 	Method          string `json:"method,omitempty"`
 	Path            string `json:"path,omitempty"`
 	RecipeID        int    `json:"recipe_id,omitempty"`
+	FlowID          int    `json:"flow_id,omitempty"`
 }
 
-// Skill represents a Workato agentic skill.
+// Skill represents a Workato agentic skill. The API returns string IDs
+// (e.g. "skl-Aa6zhmTh-4ac8TH-AB") and uses "provider_id" for the recipe
+// association; RecipeID is backfilled from ProviderID for display convenience.
 type Skill struct {
-	ID          int    `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	RecipeID    int    `json:"recipe_id"`
-	FolderID    int    `json:"folder_id"`
-	ProjectID   int    `json:"project_id"`
+	ID                 string `json:"id"`
+	Name               string `json:"name"`
+	Description        string `json:"description,omitempty"`
+	RecipeID           int    `json:"recipe_id,omitempty"`
+	ProviderID         int    `json:"provider_id"`
+	ProviderType       string `json:"provider_type,omitempty"`
+	FolderID           int    `json:"folder_id"`
+	ProjectID          int    `json:"project_id"`
+	Running            bool   `json:"running"`
+	GeniesCount        int    `json:"genies_count"`
+	TriggerDescription string `json:"trigger_description,omitempty"`
+	Applications       []any  `json:"applications,omitempty"`
 }
 
 // PaginationOptions provides generic pagination parameters.

--- a/internal/api/types_coverage_test.go
+++ b/internal/api/types_coverage_test.go
@@ -8,15 +8,25 @@ import (
 )
 
 // jsonTags extracts all json field names from a struct type,
-// stripping ",omitempty" and skipping "-" tags.
+// stripping ",omitempty" and skipping "-" tags. Recurses into
+// anonymous (embedded) fields so embedded structs contribute their tags.
 func jsonTags(t reflect.Type) map[string]bool {
 	tags := make(map[string]bool)
+	collectJSONTags(t, tags)
+	return tags
+}
+
+func collectJSONTags(t reflect.Type, tags map[string]bool) {
 	for i := 0; i < t.NumField(); i++ {
-		tag := t.Field(i).Tag.Get("json")
+		f := t.Field(i)
+		if f.Anonymous {
+			collectJSONTags(f.Type, tags)
+			continue
+		}
+		tag := f.Tag.Get("json")
 		if tag == "" || tag == "-" {
 			continue
 		}
-		// Strip options like ",omitempty"
 		if idx := len(tag); idx > 0 {
 			for j, c := range tag {
 				if c == ',' {
@@ -27,7 +37,6 @@ func jsonTags(t reflect.Type) map[string]bool {
 		}
 		tags[tag] = true
 	}
-	return tags
 }
 
 // TestStructFieldCoverage verifies that our Go structs capture all known
@@ -83,7 +92,7 @@ func TestStructFieldCoverage(t *testing.T) {
 			structType: reflect.TypeOf(APIEndpoint{}),
 			expectedFields: []string{
 				"id", "name", "api_collection_id", "active",
-				"method", "path", "recipe_id",
+				"method", "path", "recipe_id", "flow_id",
 			},
 		},
 		{
@@ -92,6 +101,22 @@ func TestStructFieldCoverage(t *testing.T) {
 			expectedFields: []string{
 				"id", "recipe_id", "status",
 				"started_at", "completed_at",
+				"title", "is_error", "error", "is_poll_error",
+				"calling_recipe_id", "calling_job_id",
+				"root_recipe_id", "root_job_id", "master_job_id",
+			},
+		},
+		{
+			name:       "JobDetail",
+			structType: reflect.TypeOf(JobDetail{}),
+			expectedFields: []string{
+				"id", "recipe_id", "status",
+				"started_at", "completed_at",
+				"title", "is_error", "error", "is_poll_error",
+				"calling_recipe_id", "calling_job_id",
+				"root_recipe_id", "root_job_id", "master_job_id",
+				"handle", "is_repeat", "is_test", "is_test_case_job",
+				"master_job_handle", "calling_job_handle", "lines",
 			},
 		},
 		{
@@ -128,6 +153,16 @@ func TestStructFieldCoverage(t *testing.T) {
 			structType: reflect.TypeOf(Connector{}),
 			expectedFields: []string{
 				"name", "title", "description",
+			},
+		},
+		{
+			name:       "Skill",
+			structType: reflect.TypeOf(Skill{}),
+			expectedFields: []string{
+				"id", "name", "description", "recipe_id",
+				"provider_id", "provider_type",
+				"folder_id", "project_id", "running",
+				"genies_count", "trigger_description", "applications",
 			},
 		},
 	}
@@ -179,6 +214,7 @@ func TestStructFieldCoverage_TableColumns(t *testing.T) {
 		"WorkspaceUser": {"id", "name", "email"},
 		"AuditLogEntry": {"id", "event_type", "user", "timestamp"},
 		"Connector":     {"name", "title", "description"},
+		"Skill":         {"id", "name", "provider_id", "folder_id", "project_id", "running"},
 	}
 
 	structTypes := map[string]reflect.Type{
@@ -191,6 +227,7 @@ func TestStructFieldCoverage_TableColumns(t *testing.T) {
 		"WorkspaceUser": reflect.TypeOf(WorkspaceUser{}),
 		"AuditLogEntry": reflect.TypeOf(AuditLogEntry{}),
 		"Connector":     reflect.TypeOf(Connector{}),
+		"Skill":         reflect.TypeOf(Skill{}),
 	}
 
 	for name, fields := range requiredTableFields {

--- a/internal/commands/agentic.go
+++ b/internal/commands/agentic.go
@@ -1,0 +1,162 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/workato-devs/wk-cli-beta/internal/api"
+	"github.com/workato-devs/wk-cli-beta/internal/output"
+)
+
+func newAgenticCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "agentic",
+		Short: "Manage Agent Studio resources",
+	}
+	cmd.AddCommand(newSkillsCmd())
+	return cmd
+}
+
+func newSkillsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "skills",
+		Aliases: []string{"skill"},
+		Short:   "Manage agentic skills",
+	}
+	cmd.AddCommand(newSkillsListCmd())
+	cmd.AddCommand(newSkillsGetCmd())
+	cmd.AddCommand(newSkillsCreateCmd())
+	return cmd
+}
+
+func newSkillsListCmd() *cobra.Command {
+	var page, perPage int
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List agentic skills",
+		Example: `  wk agentic skills list
+  wk agentic skills list --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			opts := &api.PaginationOptions{Page: page, PerPage: perPage}
+			skills, err := client.Skills().List(cmd.Context(), opts)
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"ID", "NAME", "RECIPE ID", "FOLDER ID", "PROJECT ID", "RUNNING"}
+			var rows [][]string
+			for _, s := range skills {
+				running := "no"
+				if s.Running {
+					running = "yes"
+				}
+				rows = append(rows, []string{
+					s.ID,
+					s.Name,
+					strconv.Itoa(s.RecipeID),
+					strconv.Itoa(s.FolderID),
+					strconv.Itoa(s.ProjectID),
+					running,
+				})
+			}
+			meta := output.PageMeta{Page: page, PerPage: perPage, HasNext: perPage > 0 && len(skills) == perPage}
+			return rctx.Formatter.FormatPage(os.Stdout, skills, headers, rows, meta)
+		},
+	}
+
+	cmd.Flags().IntVar(&page, "page", 0, "Page number")
+	cmd.Flags().IntVar(&perPage, "per-page", 0, "Items per page")
+	return cmd
+}
+
+func newSkillsGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get an agentic skill by ID",
+		Example: `  wk agentic skills get skl-abc123 --json`,
+		Args:  requireArgs(1, "skill ID is required, e.g.: wk agentic skills get <id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			skill, err := client.Skills().Get(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, skill)
+			}
+
+			running := "no"
+			if skill.Running {
+				running = "yes"
+			}
+			headers := []string{"ID", "NAME", "RECIPE ID", "FOLDER ID", "PROJECT ID", "RUNNING"}
+			rows := [][]string{{
+				skill.ID,
+				skill.Name,
+				strconv.Itoa(skill.RecipeID),
+				strconv.Itoa(skill.FolderID),
+				strconv.Itoa(skill.ProjectID),
+				running,
+			}}
+			return rctx.Formatter.FormatList(os.Stdout, headers, rows)
+		},
+	}
+}
+
+func newSkillsCreateCmd() *cobra.Command {
+	var recipeID int
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an agentic skill from a recipe",
+		Example: `  wk agentic skills create --recipe-id 12345 --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			skill, err := client.Skills().Create(cmd.Context(), recipeID)
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, skill)
+			}
+
+			fmt.Fprintf(os.Stderr, "Created skill %q (ID: %s)\n", skill.Name, skill.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&recipeID, "recipe-id", 0, "Recipe ID to create skill from")
+	_ = cmd.MarkFlagRequired("recipe-id")
+	return cmd
+}

--- a/internal/commands/api.go
+++ b/internal/commands/api.go
@@ -18,7 +18,6 @@ func newAPICmd() *cobra.Command {
 	}
 	cmd.AddCommand(newAPICollectionsCmd())
 	cmd.AddCommand(newAPIEndpointsCmd())
-	cmd.AddCommand(newSkillsCmd())
 	return cmd
 }
 
@@ -125,6 +124,7 @@ func newAPIEndpointsCmd() *cobra.Command {
 		Short:   "Manage API endpoints",
 	}
 	cmd.AddCommand(newAPIEndpointsListCmd())
+	cmd.AddCommand(newAPIEndpointsCreateCmd())
 	cmd.AddCommand(newAPIEndpointsEnableCmd())
 	cmd.AddCommand(newAPIEndpointsDisableCmd())
 	return cmd
@@ -187,6 +187,62 @@ func newAPIEndpointsListCmd() *cobra.Command {
 	return cmd
 }
 
+func newAPIEndpointsCreateCmd() *cobra.Command {
+	var collectionID int
+
+	cmd := &cobra.Command{
+		Use:   "create <path>",
+		Short: "Create an API endpoint from a JSON file",
+		Long: `Create an API endpoint from a JSON definition file.
+
+The file should contain: name, method, path, and flow_id (recipe ID).`,
+		Example: `  wk api endpoints create endpoint.json --collection 42
+  wk api endpoints create endpoint.json --collection 42 --json`,
+		Args: requireArgs(1, "file path is required, e.g.: wk api endpoints create <path> --collection <id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("reading file: %w", err)
+			}
+
+			ep, err := client.APIEndpoints().Create(cmd.Context(), collectionID, data)
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, ep)
+			}
+
+			fmt.Fprintf(os.Stdout, "ID:            %d\n", ep.ID)
+			fmt.Fprintf(os.Stdout, "Name:          %s\n", ep.Name)
+			fmt.Fprintf(os.Stdout, "Method:        %s\n", ep.Method)
+			fmt.Fprintf(os.Stdout, "Path:          %s\n", ep.Path)
+			fmt.Fprintf(os.Stdout, "Collection ID: %d\n", ep.APICollectionID)
+			fmt.Fprintf(os.Stdout, "Recipe ID:     %d\n", ep.RecipeID)
+			active := "no"
+			if ep.Active {
+				active = "yes"
+			}
+			fmt.Fprintf(os.Stdout, "Active:        %s\n", active)
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&collectionID, "collection", 0, "API collection ID")
+	_ = cmd.MarkFlagRequired("collection")
+	return cmd
+}
+
 func newAPIEndpointsEnableCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "enable <id>",
@@ -241,140 +297,3 @@ func newAPIEndpointsDisableCmd() *cobra.Command {
 	}
 }
 
-func newSkillsCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "skills",
-		Aliases: []string{"skill"},
-		Short:   "Manage agentic skills",
-	}
-	cmd.AddCommand(newSkillsListCmd())
-	cmd.AddCommand(newSkillsGetCmd())
-	cmd.AddCommand(newSkillsCreateCmd())
-	return cmd
-}
-
-func newSkillsListCmd() *cobra.Command {
-	var page, perPage int
-
-	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "List agentic skills",
-		Example: `  wk api skills list
-  wk api skills list --json`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			rctx, err := BuildRunContext(cmd)
-			if err != nil {
-				return err
-			}
-			client, _, err := resolveAPIClient(cmd)
-			if err != nil {
-				return err
-			}
-
-			opts := &api.PaginationOptions{Page: page, PerPage: perPage}
-			skills, err := client.Skills().List(cmd.Context(), opts)
-			if err != nil {
-				return err
-			}
-
-			headers := []string{"ID", "NAME", "DESCRIPTION", "RECIPE ID", "FOLDER ID", "PROJECT ID"}
-			var rows [][]string
-			for _, s := range skills {
-				rows = append(rows, []string{
-					strconv.Itoa(s.ID),
-					s.Name,
-					s.Description,
-					strconv.Itoa(s.RecipeID),
-					strconv.Itoa(s.FolderID),
-					strconv.Itoa(s.ProjectID),
-				})
-			}
-			meta := output.PageMeta{Page: page, PerPage: perPage, HasNext: perPage > 0 && len(skills) == perPage}
-			return rctx.Formatter.FormatPage(os.Stdout, skills, headers, rows, meta)
-		},
-	}
-
-	cmd.Flags().IntVar(&page, "page", 0, "Page number")
-	cmd.Flags().IntVar(&perPage, "per-page", 0, "Items per page")
-	return cmd
-}
-
-func newSkillsGetCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "get <id>",
-		Short: "Get an agentic skill by ID",
-		Example: `  wk api skills get 42 --json`,
-		Args:  requireArgs(1, "skill ID is required, e.g.: wk api skills get <id>"),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			rctx, err := BuildRunContext(cmd)
-			if err != nil {
-				return err
-			}
-			client, _, err := resolveAPIClient(cmd)
-			if err != nil {
-				return err
-			}
-
-			id, err := strconv.Atoi(args[0])
-			if err != nil {
-				return fmt.Errorf("invalid skill ID: %s", args[0])
-			}
-
-			skill, err := client.Skills().Get(cmd.Context(), id)
-			if err != nil {
-				return err
-			}
-
-			if flagJSON {
-				return rctx.Formatter.Format(os.Stdout, skill)
-			}
-
-			headers := []string{"ID", "NAME", "DESCRIPTION", "RECIPE ID", "FOLDER ID", "PROJECT ID"}
-			rows := [][]string{{
-				strconv.Itoa(skill.ID),
-				skill.Name,
-				skill.Description,
-				strconv.Itoa(skill.RecipeID),
-				strconv.Itoa(skill.FolderID),
-				strconv.Itoa(skill.ProjectID),
-			}}
-			return rctx.Formatter.FormatList(os.Stdout, headers, rows)
-		},
-	}
-}
-
-func newSkillsCreateCmd() *cobra.Command {
-	var recipeID int
-
-	cmd := &cobra.Command{
-		Use:   "create",
-		Short: "Create an agentic skill from a recipe",
-		Example: `  wk api skills create --recipe-id 12345 --json`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			rctx, err := BuildRunContext(cmd)
-			if err != nil {
-				return err
-			}
-			client, _, err := resolveAPIClient(cmd)
-			if err != nil {
-				return err
-			}
-
-			skill, err := client.Skills().Create(cmd.Context(), recipeID)
-			if err != nil {
-				return err
-			}
-
-			if flagJSON {
-				return rctx.Formatter.Format(os.Stdout, skill)
-			}
-
-			fmt.Fprintf(os.Stderr, "Created skill %q (ID: %d)\n", skill.Name, skill.ID)
-			return nil
-		},
-	}
-
-	cmd.Flags().IntVar(&recipeID, "recipe-id", 0, "Recipe ID to create skill from")
-	_ = cmd.MarkFlagRequired("recipe-id")
-	return cmd
-}

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -26,6 +26,7 @@ func newAuthCmd() *cobra.Command {
 	cmd.AddCommand(newAuthSwitchCmd())
 	cmd.AddCommand(newAuthListCmd())
 	cmd.AddCommand(newAuthDeleteCmd())
+	cmd.AddCommand(newAuthTokenCmd())
 	return cmd
 }
 
@@ -548,6 +549,53 @@ func newAuthDeleteCmd() *cobra.Command {
 
 			fmt.Fprintf(os.Stderr, "Deleted profile %q (workspace: %s, environment: %s)\n",
 				profile.Name, profile.Workspace, profile.Environment)
+			return nil
+		},
+	}
+}
+
+func newAuthTokenCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "token",
+		Short: "Print the active profile's API token",
+		Long: `Print the API token for the active profile (or --profile override) to stdout.
+
+Intended for scripting: pipe the output to other tools or assign it to a
+variable. When stdout is a terminal, a warning is printed to stderr.`,
+		Example: `  # Pipe to curl
+  curl -H "Authorization: Bearer $(wk auth token)" https://www.workato.com/api/users/me
+
+  # Assign to variable
+  TOKEN=$(wk auth token)
+
+  # JSON output
+  wk auth token --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			activeName, _, err := resolveActiveProfileName()
+			if err != nil {
+				return err
+			}
+			_, cred, err := resolveProfileAndCred(cmd.Context(), activeName)
+			if err != nil {
+				return err
+			}
+
+			if term.IsTerminal(os.Stdout) {
+				fmt.Fprintf(os.Stderr, "Warning: token is being printed to a terminal; prefer piping to avoid exposure\n")
+			}
+
+			if flagJSON {
+				rctx, rerr := BuildRunContext(cmd)
+				if rerr != nil {
+					return rerr
+				}
+				return rctx.Formatter.Format(os.Stdout, map[string]string{"token": cred.Token})
+			}
+
+			fmt.Fprint(os.Stdout, cred.Token)
+			if term.IsTerminal(os.Stdout) {
+				fmt.Fprintln(os.Stdout)
+			}
 			return nil
 		},
 	}

--- a/internal/commands/recipe.go
+++ b/internal/commands/recipe.go
@@ -192,8 +192,8 @@ func newRecipesStartCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("checking recipe status: %w", err)
 				}
-				if recipe.Running && recipe.Active {
-					fmt.Fprintf(os.Stderr, "Recipe %d started and active\n", id)
+				if recipe.Running {
+					fmt.Fprintf(os.Stderr, "Recipe %d started and running\n", id)
 					return nil
 				}
 				time.Sleep(interval)
@@ -330,11 +330,11 @@ func newRecipesJobsCmd() *cobra.Command {
 	var limit int
 
 	cmd := &cobra.Command{
-		Use:   "jobs <id>",
+		Use:   "jobs <recipe-id>",
 		Short: "List recipe jobs",
 		Example: `  wk recipes jobs 12345
   wk recipes jobs 12345 --status failed --limit 10 --json`,
-		Args:  requireArgs(1, "recipe ID is required, e.g.: wk recipes jobs <id>"),
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rctx, err := BuildRunContext(cmd)
 			if err != nil {
@@ -364,7 +364,7 @@ func newRecipesJobsCmd() *cobra.Command {
 				return rctx.Formatter.Format(os.Stdout, jobs)
 			}
 
-			headers := []string{"ID", "STATUS", "STARTED AT", "COMPLETED AT"}
+			headers := []string{"ID", "STATUS", "STARTED AT", "COMPLETED AT", "ERROR"}
 			var rows [][]string
 			for _, j := range jobs {
 				started := ""
@@ -375,11 +375,16 @@ func newRecipesJobsCmd() *cobra.Command {
 				if j.CompletedAt != nil {
 					completed = j.CompletedAt.Format(time.RFC3339)
 				}
+				errMsg := ""
+				if j.Error != nil {
+					errMsg = *j.Error
+				}
 				rows = append(rows, []string{
-					strconv.Itoa(j.ID),
+					j.ID,
 					j.Status,
 					started,
 					completed,
+					errMsg,
 				})
 			}
 			return rctx.Formatter.FormatList(os.Stdout, headers, rows)
@@ -388,7 +393,81 @@ func newRecipesJobsCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&status, "status", "all", "Filter by status (succeeded, failed, all)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum number of jobs to return")
+	cmd.AddCommand(newRecipesJobsGetCmd())
 	return cmd
+}
+
+func newRecipesJobsGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <recipe-id> <job-id>",
+		Short: "Get details for a single job, including step traces",
+		Example: `  wk recipes jobs get 12345 67890
+  wk recipes jobs get 12345 67890 --json`,
+		Args: requireArgs(2, "recipe ID and job ID are required, e.g.: wk recipes jobs get <recipe-id> <job-id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			recipeID, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid recipe ID: %s", args[0])
+			}
+
+			detail, err := client.Recipes().GetJob(cmd.Context(), recipeID, args[1])
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, detail)
+			}
+
+			fmt.Fprintf(os.Stdout, "Job ID:     %s\n", detail.ID)
+			fmt.Fprintf(os.Stdout, "Recipe ID:  %d\n", detail.RecipeID)
+			fmt.Fprintf(os.Stdout, "Status:     %s\n", detail.Status)
+			if detail.StartedAt != nil {
+				fmt.Fprintf(os.Stdout, "Started:    %s\n", detail.StartedAt.Format(time.RFC3339))
+			}
+			if detail.CompletedAt != nil {
+				fmt.Fprintf(os.Stdout, "Completed:  %s\n", detail.CompletedAt.Format(time.RFC3339))
+			}
+			if detail.Error != nil {
+				fmt.Fprintf(os.Stdout, "Error:      %s\n", *detail.Error)
+			}
+
+			if len(detail.Lines) > 0 {
+				fmt.Fprintln(os.Stdout)
+				headers := []string{"STEP", "ADAPTER", "OPERATION", "STARTED AT", "COMPLETED AT"}
+				var rows [][]string
+				for _, line := range detail.Lines {
+					started, completed := "", ""
+					if line.LineStat != nil {
+						if line.LineStat.StartedAt != nil {
+							started = line.LineStat.StartedAt.Format(time.RFC3339)
+						}
+						if line.LineStat.CompletedAt != nil {
+							completed = line.LineStat.CompletedAt.Format(time.RFC3339)
+						}
+					}
+					rows = append(rows, []string{
+						strconv.Itoa(line.RecipeLineNumber),
+						line.AdapterName,
+						line.AdapterOperation,
+						started,
+						completed,
+					})
+				}
+				return rctx.Formatter.FormatList(os.Stdout, headers, rows)
+			}
+			return nil
+		},
+	}
 }
 
 func newRecipesCopyCmd() *cobra.Command {

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -213,6 +213,7 @@ func registerAllCommands(root *cobra.Command) {
 	root.AddCommand(newFoldersCmd())
 	root.AddCommand(newTagsCmd())
 	root.AddCommand(newAPICmd())
+	root.AddCommand(newAgenticCmd())
 	root.AddCommand(newMCPCmd())
 	root.AddCommand(newWorkspaceCmd())
 	root.AddCommand(newConnectorsCmd())


### PR DESCRIPTION
Major changes:

Recipe commands
- Enriched `recipes jobs` with error info + `jobs get`
- Fix `recipes start` polling condition (polling always timed out)
- Add `recipes import` name backfill (auto add name after import when missing)

API commands
- Added `wk api endpoints create` from JSON file

Auth commands
- Added `wk auth token` (with TTY warning)

Skill commands (new)
- Added `wk agentic skills` (new namespace and commands) for get, list, post skills

Based on awesome feedback from Todd Hayes