### PR TITLE
Zt/feature dev

### DIFF
--- a/internal/api/api_clients.go
+++ b/internal/api/api_clients.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+type apiClientService struct {
+	client *HTTPClient
+}
+
+func (s *apiClientService) List(ctx context.Context, opts *PaginationOptions) ([]APIClient, error) {
+	params := url.Values{}
+	if opts != nil {
+		if opts.Page > 0 {
+			params.Set("page", strconv.Itoa(opts.Page))
+		}
+		if opts.PerPage > 0 {
+			params.Set("per_page", strconv.Itoa(opts.PerPage))
+		}
+	}
+	path := "/v2/api_clients"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+	var wrapper struct {
+		Data []APIClient `json:"data"`
+	}
+	if err := s.client.do(ctx, "GET", path, nil, &wrapper); err != nil {
+		return nil, err
+	}
+	return wrapper.Data, nil
+}
+
+func (s *apiClientService) Get(ctx context.Context, id int) (*APIClient, error) {
+	var wrapper struct {
+		Data APIClient `json:"data"`
+	}
+	if err := s.client.do(ctx, "GET", fmt.Sprintf("/v2/api_clients/%d", id), nil, &wrapper); err != nil {
+		return nil, err
+	}
+	return &wrapper.Data, nil
+}
+
+func (s *apiClientService) Create(ctx context.Context, name string, collectionIDs []string, authType string) (*APIClient, error) {
+	body := map[string]any{
+		"name": name,
+	}
+	if len(collectionIDs) > 0 {
+		body["api_collection_ids"] = collectionIDs
+	}
+	if authType != "" {
+		body["auth_type"] = authType
+	}
+	var wrapper struct {
+		Data APIClient `json:"data"`
+	}
+	if err := s.client.do(ctx, "POST", "/v2/api_clients", body, &wrapper); err != nil {
+		return nil, err
+	}
+	return &wrapper.Data, nil
+}
+
+func (s *apiClientService) Delete(ctx context.Context, id int) error {
+	return s.client.do(ctx, "DELETE", fmt.Sprintf("/v2/api_clients/%d", id), nil, nil)
+}
+
+func (s *apiClientService) CreateKey(ctx context.Context, clientID int, name string) (*APIKey, error) {
+	body := map[string]any{
+		"name":   name,
+		"active": true,
+	}
+	var wrapper struct {
+		Data APIKey `json:"data"`
+	}
+	path := fmt.Sprintf("/v2/api_clients/%d/api_keys", clientID)
+	if err := s.client.do(ctx, "POST", path, body, &wrapper); err != nil {
+		return nil, err
+	}
+	return &wrapper.Data, nil
+}
+
+func (s *apiClientService) RefreshKey(ctx context.Context, clientID, keyID int) (*APIKey, error) {
+	var wrapper struct {
+		Data APIKey `json:"data"`
+	}
+	path := fmt.Sprintf("/v2/api_clients/%d/api_keys/%d/refresh_secret", clientID, keyID)
+	if err := s.client.do(ctx, "PUT", path, nil, &wrapper); err != nil {
+		return nil, err
+	}
+	return &wrapper.Data, nil
+}

--- a/internal/api/api_clients_test.go
+++ b/internal/api/api_clients_test.go
@@ -1,0 +1,212 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAPIClientService_List(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v2/api_clients" {
+			t.Errorf("path = %s, want /v2/api_clients", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[{"id":1,"name":"test-client","auth_type":"token","active_api_keys_count":2}],"count":1,"page":1,"per_page":100}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	clients, err := client.APIClients().List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clients) != 1 {
+		t.Fatalf("got %d clients, want 1", len(clients))
+	}
+	if clients[0].Name != "test-client" {
+		t.Errorf("Name = %q, want %q", clients[0].Name, "test-client")
+	}
+	if clients[0].AuthType != "token" {
+		t.Errorf("AuthType = %q, want %q", clients[0].AuthType, "token")
+	}
+	if clients[0].ActiveAPIKeysCount != 2 {
+		t.Errorf("ActiveAPIKeysCount = %d, want 2", clients[0].ActiveAPIKeysCount)
+	}
+}
+
+func TestAPIClientService_ListWithPagination(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("page") != "2" {
+			t.Errorf("page = %q, want 2", r.URL.Query().Get("page"))
+		}
+		if r.URL.Query().Get("per_page") != "10" {
+			t.Errorf("per_page = %q, want 10", r.URL.Query().Get("per_page"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[],"count":0,"page":2,"per_page":10}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	clients, err := client.APIClients().List(context.Background(), &PaginationOptions{Page: 2, PerPage: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clients) != 0 {
+		t.Errorf("got %d clients, want 0", len(clients))
+	}
+}
+
+func TestAPIClientService_Get(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v2/api_clients/42" {
+			t.Errorf("path = %s, want /v2/api_clients/42", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"id":42,"name":"prod-client","auth_type":"token","api_collections":[{"id":1,"name":"v1"}],"api_keys":[{"id":10,"name":"key-1","active":true}]}}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	ac, err := client.APIClients().Get(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ac.ID != 42 {
+		t.Errorf("ID = %d, want 42", ac.ID)
+	}
+	if len(ac.APICollections) != 1 || ac.APICollections[0].Name != "v1" {
+		t.Errorf("APICollections = %+v, want 1 collection named v1", ac.APICollections)
+	}
+	if len(ac.APIKeys) != 1 || ac.APIKeys[0].Name != "key-1" {
+		t.Errorf("APIKeys = %+v, want 1 key named key-1", ac.APIKeys)
+	}
+}
+
+func TestAPIClientService_Create(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v2/api_clients" {
+			t.Errorf("path = %s, want /v2/api_clients", r.URL.Path)
+		}
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["name"] != "new-client" {
+			t.Errorf("name = %v, want new-client", body["name"])
+		}
+		if body["auth_type"] != "token" {
+			t.Errorf("auth_type = %v, want token", body["auth_type"])
+		}
+		ids, ok := body["api_collection_ids"].([]any)
+		if !ok || len(ids) != 2 {
+			t.Errorf("api_collection_ids = %v, want [\"1\",\"2\"]", body["api_collection_ids"])
+		} else {
+			if ids[0] != "1" || ids[1] != "2" {
+				t.Errorf("api_collection_ids = %v, want [\"1\",\"2\"]", ids)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"id":99,"name":"new-client","auth_type":"token"}}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	ac, err := client.APIClients().Create(context.Background(), "new-client", []string{"1", "2"}, "token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ac.ID != 99 {
+		t.Errorf("ID = %d, want 99", ac.ID)
+	}
+}
+
+func TestAPIClientService_Delete(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/v2/api_clients/42" {
+			t.Errorf("path = %s, want /v2/api_clients/42", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"success":true}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	err := client.APIClients().Delete(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAPIClientService_CreateKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/v2/api_clients/42/api_keys" {
+			t.Errorf("path = %s, want /v2/api_clients/42/api_keys", r.URL.Path)
+		}
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["name"] != "prod-key" {
+			t.Errorf("name = %v, want prod-key", body["name"])
+		}
+		if body["active"] != true {
+			t.Errorf("active = %v, want true", body["active"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"id":10,"name":"prod-key","auth_type":"token","auth_token":"secret-abc-123","active":true}}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	key, err := client.APIClients().CreateKey(context.Background(), 42, "prod-key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key.ID != 10 {
+		t.Errorf("ID = %d, want 10", key.ID)
+	}
+	if key.AuthToken != "secret-abc-123" {
+		t.Errorf("AuthToken = %q, want %q", key.AuthToken, "secret-abc-123")
+	}
+	if !key.Active {
+		t.Error("Active = false, want true")
+	}
+}
+
+func TestAPIClientService_RefreshKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/v2/api_clients/42/api_keys/10/refresh_secret" {
+			t.Errorf("path = %s, want /v2/api_clients/42/api_keys/10/refresh_secret", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"id":10,"name":"prod-key","auth_type":"token","auth_token":"new-secret-456","active":true}}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	key, err := client.APIClients().RefreshKey(context.Background(), 42, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key.AuthToken != "new-secret-456" {
+		t.Errorf("AuthToken = %q, want %q", key.AuthToken, "new-secret-456")
+	}
+}

--- a/internal/api/api_collections.go
+++ b/internal/api/api_collections.go
@@ -31,10 +31,12 @@ func (s *apiCollectionService) List(ctx context.Context, opts *PaginationOptions
 	return result, nil
 }
 
-func (s *apiCollectionService) Create(ctx context.Context, name string, projectID int) (*APICollection, error) {
+func (s *apiCollectionService) Create(ctx context.Context, name string, projectID *int) (*APICollection, error) {
 	body := map[string]any{
-		"name":       name,
-		"project_id": projectID,
+		"name": name,
+	}
+	if projectID != nil {
+		body["project_id"] = *projectID
 	}
 	var collection APICollection
 	if err := s.client.do(ctx, "POST", "/api_collections", body, &collection); err != nil {

--- a/internal/api/api_collections_test.go
+++ b/internal/api/api_collections_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 )
 
+func intPtr(v int) *int { return &v }
+
 func TestAPICollectionService_List(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
@@ -17,8 +19,7 @@ func TestAPICollectionService_List(t *testing.T) {
 			t.Errorf("path = %s, want /api_collections", r.URL.Path)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		// Production expects raw array (no wrapper).
-		json.NewEncoder(w).Encode([]APICollection{{ID: 1, Name: "v1", Handle: "v1-handle", Version: "1.0", Description: "test collection", UsePrefix: true, ProjectID: 10}})
+		json.NewEncoder(w).Encode([]APICollection{{ID: 1, Name: "v1", Version: "1.0", URL: "https://example.com/v1", ProjectID: intPtr(10)}})
 	}))
 	defer srv.Close()
 
@@ -31,17 +32,14 @@ func TestAPICollectionService_List(t *testing.T) {
 		t.Errorf("got %+v, want 1 collection named v1", collections)
 	}
 	c := collections[0]
-	if c.Handle != "v1-handle" {
-		t.Errorf("Handle = %q, want %q", c.Handle, "v1-handle")
-	}
 	if c.Version != "1.0" {
 		t.Errorf("Version = %q, want %q", c.Version, "1.0")
 	}
-	if c.Description != "test collection" {
-		t.Errorf("Description = %q, want %q", c.Description, "test collection")
+	if c.URL != "https://example.com/v1" {
+		t.Errorf("URL = %q, want %q", c.URL, "https://example.com/v1")
 	}
-	if !c.UsePrefix {
-		t.Error("UsePrefix = false, want true")
+	if c.ProjectID == nil || *c.ProjectID != 10 {
+		t.Errorf("ProjectID = %v, want 10", c.ProjectID)
 	}
 }
 
@@ -55,17 +53,45 @@ func TestAPICollectionService_Create(t *testing.T) {
 		if body["name"] != "v2" {
 			t.Errorf("name = %v, want v2", body["name"])
 		}
+		if body["project_id"] != float64(10) {
+			t.Errorf("project_id = %v, want 10", body["project_id"])
+		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(APICollection{ID: 2, Name: "v2", ProjectID: 10})
+		json.NewEncoder(w).Encode(APICollection{ID: 2, Name: "v2", ProjectID: intPtr(10)})
 	}))
 	defer srv.Close()
 
 	client := NewHTTPClient(srv.URL, "test-token")
-	c, err := client.APICollections().Create(context.Background(), "v2", 10)
+	c, err := client.APICollections().Create(context.Background(), "v2", intPtr(10))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if c.ID != 2 {
 		t.Errorf("ID = %d, want 2", c.ID)
+	}
+}
+
+func TestAPICollectionService_CreateWithoutProject(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if _, ok := body["project_id"]; ok {
+			t.Error("project_id should not be sent when nil")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(APICollection{ID: 3, Name: "no-project"})
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	c, err := client.APICollections().Create(context.Background(), "no-project", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.ID != 3 {
+		t.Errorf("ID = %d, want 3", c.ID)
+	}
+	if c.ProjectID != nil {
+		t.Errorf("ProjectID = %v, want nil", c.ProjectID)
 	}
 }

--- a/internal/api/api_endpoints.go
+++ b/internal/api/api_endpoints.go
@@ -33,6 +33,9 @@ func (s *apiEndpointService) List(ctx context.Context, collectionID *int, opts *
 	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
+	for i := range result {
+		backfillEndpointRecipeID(&result[i])
+	}
 	return result, nil
 }
 
@@ -45,10 +48,14 @@ func (s *apiEndpointService) Create(ctx context.Context, collectionID int, data 
 	if err := s.client.do(ctx, "POST", fmt.Sprintf("/api_collections/%d/api_endpoints", collectionID), body, &ep); err != nil {
 		return nil, err
 	}
+	backfillEndpointRecipeID(&ep)
+	return &ep, nil
+}
+
+func backfillEndpointRecipeID(ep *APIEndpoint) {
 	if ep.RecipeID == 0 && ep.FlowID != 0 {
 		ep.RecipeID = ep.FlowID
 	}
-	return &ep, nil
 }
 
 func (s *apiEndpointService) Enable(ctx context.Context, id int) error {

--- a/internal/api/api_endpoints_test.go
+++ b/internal/api/api_endpoints_test.go
@@ -17,8 +17,7 @@ func TestAPIEndpointService_List(t *testing.T) {
 			t.Errorf("api_collection_id = %q, want 5", cid)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		// Production expects raw array (no wrapper).
-		json.NewEncoder(w).Encode([]APIEndpoint{{ID: 1, Name: "ep1", APICollectionID: 5, Active: true, Method: "GET", Path: "/users", RecipeID: 42}})
+		w.Write([]byte(`[{"id":1,"name":"ep1","api_collection_id":5,"active":true,"method":"GET","path":"/users","flow_id":42,"description":"test desc"}]`))
 	}))
 	defer srv.Close()
 
@@ -38,8 +37,14 @@ func TestAPIEndpointService_List(t *testing.T) {
 	if ep.Path != "/users" {
 		t.Errorf("Path = %q, want %q", ep.Path, "/users")
 	}
+	if ep.FlowID != 42 {
+		t.Errorf("FlowID = %d, want 42", ep.FlowID)
+	}
 	if ep.RecipeID != 42 {
-		t.Errorf("RecipeID = %d, want 42", ep.RecipeID)
+		t.Errorf("RecipeID = %d, want 42 (backfilled from FlowID)", ep.RecipeID)
+	}
+	if ep.Description == nil || *ep.Description != "test desc" {
+		t.Errorf("Description = %v, want %q", ep.Description, "test desc")
 	}
 }
 
@@ -59,13 +64,16 @@ func TestAPIEndpointService_Create(t *testing.T) {
 		if body["flow_id"] != float64(42) {
 			t.Errorf("flow_id = %v, want 42", body["flow_id"])
 		}
+		if body["description"] != "Creates a user" {
+			t.Errorf("description = %v, want Creates a user", body["description"])
+		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"id":99,"name":"Create User","api_collection_id":5,"active":false,"method":"POST","path":"/users","flow_id":42}`))
+		w.Write([]byte(`{"id":99,"name":"Create User","api_collection_id":5,"active":false,"method":"POST","path":"/users","flow_id":42,"description":"Creates a user"}`))
 	}))
 	defer srv.Close()
 
 	client := NewHTTPClient(srv.URL, "test-token")
-	data := []byte(`{"name":"Create User","method":"POST","path":"/users","flow_id":42}`)
+	data := []byte(`{"name":"Create User","method":"POST","path":"/users","flow_id":42,"description":"Creates a user"}`)
 	ep, err := client.APIEndpoints().Create(context.Background(), 5, data)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -78,10 +78,20 @@ type TagService interface {
 	Assign(ctx context.Context, addTags, removeTags []string, recipeIDs, connectionIDs []int) error
 }
 
+// APIClientService defines operations on API Platform clients (v2 API).
+type APIClientService interface {
+	List(ctx context.Context, opts *PaginationOptions) ([]APIClient, error)
+	Get(ctx context.Context, id int) (*APIClient, error)
+	Create(ctx context.Context, name string, collectionIDs []string, authType string) (*APIClient, error)
+	Delete(ctx context.Context, id int) error
+	CreateKey(ctx context.Context, clientID int, name string) (*APIKey, error)
+	RefreshKey(ctx context.Context, clientID, keyID int) (*APIKey, error)
+}
+
 // APICollectionService defines operations on API collections.
 type APICollectionService interface {
 	List(ctx context.Context, opts *PaginationOptions) ([]APICollection, error)
-	Create(ctx context.Context, name string, projectID int) (*APICollection, error)
+	Create(ctx context.Context, name string, projectID *int) (*APICollection, error)
 }
 
 // APIEndpointService defines operations on API endpoints.
@@ -120,6 +130,7 @@ type Client interface {
 	Tags() TagService
 	APICollections() APICollectionService
 	APIEndpoints() APIEndpointService
+	APIClients() APIClientService
 	Skills() SkillService
 	Workspace() WorkspaceService
 	Connectors() ConnectorService

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -109,6 +109,17 @@ type SkillService interface {
 	Create(ctx context.Context, recipeID int) (*Skill, error)
 }
 
+// MCPServerService defines operations on MCP managed servers (/api/mcp/mcp_servers).
+type MCPServerService interface {
+	List(ctx context.Context, opts *MCPServerListOptions) ([]MCPManagedServer, error)
+	Get(ctx context.Context, handle string) (*MCPManagedServer, error)
+	Create(ctx context.Context, name string, folderID int, description string, assetID *int) (*MCPManagedServer, error)
+	Update(ctx context.Context, handle string, opts map[string]any) (*MCPManagedServer, error)
+	Delete(ctx context.Context, handle string) error
+	TokenRenew(ctx context.Context, handle string) (*MCPManagedServer, error)
+	ListTools(ctx context.Context, handle string, opts *PaginationOptions) ([]MCPServerTool, error)
+}
+
 // WorkspaceService defines operations on workspace management.
 type WorkspaceService interface {
 	GetCurrentWorkspace(ctx context.Context) (*WorkspaceInfo, error)
@@ -132,6 +143,7 @@ type Client interface {
 	APIEndpoints() APIEndpointService
 	APIClients() APIClientService
 	Skills() SkillService
+	MCPServers() MCPServerService
 	Workspace() WorkspaceService
 	Connectors() ConnectorService
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -16,6 +16,7 @@ type RecipeService interface {
 	GetJob(ctx context.Context, recipeID int, jobID string) (*JobDetail, error)
 	Copy(ctx context.Context, recipeID, folderID int) (*Recipe, error)
 	Connect(ctx context.Context, recipeID int, adapterName string, connectionID int) error
+	RepeatJobs(ctx context.Context, recipeID int, jobIDs []string) (*RepeatJobsResult, error)
 	ListVersions(ctx context.Context, recipeID, page, perPage int) ([]RecipeVersion, error)
 	GetVersion(ctx context.Context, recipeID, versionID int) (*RecipeVersion, error)
 	UpdateVersionComment(ctx context.Context, recipeID, versionID int, comment string) (*RecipeVersion, error)
@@ -125,6 +126,8 @@ type WorkspaceService interface {
 	GetCurrentWorkspace(ctx context.Context) (*WorkspaceInfo, error)
 	ListMembers(ctx context.Context, email string) ([]WorkspaceUser, error)
 	GetAuditLogs(ctx context.Context, opts *AuditLogOptions) ([]AuditLogEntry, error)
+	ListProperties(ctx context.Context, prefix string) (map[string]string, error)
+	SetProperties(ctx context.Context, properties map[string]string) error
 }
 
 // ConnectorService defines operations on connectors.

--- a/internal/api/http_client.go
+++ b/internal/api/http_client.go
@@ -27,6 +27,7 @@ type HTTPClient struct {
 	apiEndpoints   *apiEndpointService
 	apiClients     *apiClientService
 	skills         *skillService
+	mcpServers     *mcpServerService
 	workspace      *workspaceService
 	connectors     *connectorService
 }
@@ -131,6 +132,13 @@ func (c *HTTPClient) Skills() SkillService {
 		c.skills = &skillService{client: c}
 	}
 	return c.skills
+}
+
+func (c *HTTPClient) MCPServers() MCPServerService {
+	if c.mcpServers == nil {
+		c.mcpServers = &mcpServerService{client: c}
+	}
+	return c.mcpServers
 }
 
 func (c *HTTPClient) Workspace() WorkspaceService {

--- a/internal/api/http_client.go
+++ b/internal/api/http_client.go
@@ -25,6 +25,7 @@ type HTTPClient struct {
 	tags           *tagService
 	apiCollections *apiCollectionService
 	apiEndpoints   *apiEndpointService
+	apiClients     *apiClientService
 	skills         *skillService
 	workspace      *workspaceService
 	connectors     *connectorService
@@ -116,6 +117,13 @@ func (c *HTTPClient) APIEndpoints() APIEndpointService {
 		c.apiEndpoints = &apiEndpointService{client: c}
 	}
 	return c.apiEndpoints
+}
+
+func (c *HTTPClient) APIClients() APIClientService {
+	if c.apiClients == nil {
+		c.apiClients = &apiClientService{client: c}
+	}
+	return c.apiClients
 }
 
 func (c *HTTPClient) Skills() SkillService {

--- a/internal/api/mcp_servers.go
+++ b/internal/api/mcp_servers.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+type mcpServerService struct {
+	client *HTTPClient
+}
+
+func (s *mcpServerService) List(ctx context.Context, opts *MCPServerListOptions) ([]MCPManagedServer, error) {
+	params := url.Values{}
+	if opts != nil {
+		if opts.ProjectID != nil {
+			params.Set("project_id", strconv.Itoa(*opts.ProjectID))
+		}
+		if opts.FolderID != nil {
+			params.Set("folder_id", strconv.Itoa(*opts.FolderID))
+		}
+		if opts.AuthenticationMethod != "" {
+			params.Set("authentication_method", opts.AuthenticationMethod)
+		}
+		if opts.Page > 0 {
+			params.Set("page", strconv.Itoa(opts.Page))
+		}
+		if opts.PerPage > 0 {
+			params.Set("per_page", strconv.Itoa(opts.PerPage))
+		}
+	}
+	path := "/mcp/mcp_servers"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+	var wrapper struct {
+		Data []MCPManagedServer `json:"data"`
+	}
+	if err := s.client.do(ctx, "GET", path, nil, &wrapper); err != nil {
+		return nil, err
+	}
+	return wrapper.Data, nil
+}
+
+func (s *mcpServerService) Get(ctx context.Context, handle string) (*MCPManagedServer, error) {
+	var wrapper struct {
+		Data MCPManagedServer `json:"data"`
+	}
+	if err := s.client.do(ctx, "GET", fmt.Sprintf("/mcp/mcp_servers/%s", handle), nil, &wrapper); err != nil {
+		return nil, err
+	}
+	return &wrapper.Data, nil
+}
+
+func (s *mcpServerService) Create(ctx context.Context, name string, folderID int, description string, assetID *int) (*MCPManagedServer, error) {
+	body := map[string]any{
+		"name":      name,
+		"folder_id": folderID,
+	}
+	if description != "" {
+		body["description"] = description
+	}
+	if assetID != nil {
+		body["asset_id"] = *assetID
+	}
+	var wrapper struct {
+		Data MCPManagedServer `json:"data"`
+	}
+	if err := s.client.do(ctx, "POST", "/mcp/mcp_servers", body, &wrapper); err != nil {
+		return nil, err
+	}
+	return &wrapper.Data, nil
+}
+
+func (s *mcpServerService) Update(ctx context.Context, handle string, opts map[string]any) (*MCPManagedServer, error) {
+	var wrapper struct {
+		Data MCPManagedServer `json:"data"`
+	}
+	if err := s.client.do(ctx, "PUT", fmt.Sprintf("/mcp/mcp_servers/%s", handle), opts, &wrapper); err != nil {
+		return nil, err
+	}
+	return &wrapper.Data, nil
+}
+
+func (s *mcpServerService) Delete(ctx context.Context, handle string) error {
+	return s.client.do(ctx, "DELETE", fmt.Sprintf("/mcp/mcp_servers/%s", handle), nil, nil)
+}
+
+func (s *mcpServerService) TokenRenew(ctx context.Context, handle string) (*MCPManagedServer, error) {
+	var wrapper struct {
+		Data MCPManagedServer `json:"data"`
+	}
+	if err := s.client.do(ctx, "POST", fmt.Sprintf("/mcp/mcp_servers/%s/token_renew", handle), nil, &wrapper); err != nil {
+		return nil, err
+	}
+	return &wrapper.Data, nil
+}
+
+func (s *mcpServerService) ListTools(ctx context.Context, handle string, opts *PaginationOptions) ([]MCPServerTool, error) {
+	params := url.Values{}
+	if opts != nil {
+		if opts.Page > 0 {
+			params.Set("page", strconv.Itoa(opts.Page))
+		}
+		if opts.PerPage > 0 {
+			params.Set("per_page", strconv.Itoa(opts.PerPage))
+		}
+	}
+	path := fmt.Sprintf("/mcp/mcp_servers/%s/tools", handle)
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+	// Tools endpoint returns {"items":[...]} not {"data":[...]}
+	var wrapper struct {
+		Items []MCPServerTool `json:"items"`
+	}
+	if err := s.client.do(ctx, "GET", path, nil, &wrapper); err != nil {
+		return nil, err
+	}
+	return wrapper.Items, nil
+}

--- a/internal/api/mcp_servers_test.go
+++ b/internal/api/mcp_servers_test.go
@@ -1,0 +1,249 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMCPServerService_List(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/mcp/mcp_servers" {
+			t.Errorf("path = %s, want /mcp/mcp_servers", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[{"id":"mcps-abc","name":"test-server","authentication_method":"token","tools_count":5,"folder_id":100,"project_id":42}],"count":1,"page":1,"per_page":20}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	servers, err := client.MCPServers().List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("got %d servers, want 1", len(servers))
+	}
+	if servers[0].ID != "mcps-abc" {
+		t.Errorf("ID = %q, want %q", servers[0].ID, "mcps-abc")
+	}
+	if servers[0].Name != "test-server" {
+		t.Errorf("Name = %q, want %q", servers[0].Name, "test-server")
+	}
+	if servers[0].ToolsCount != 5 {
+		t.Errorf("ToolsCount = %d, want 5", servers[0].ToolsCount)
+	}
+}
+
+func TestMCPServerService_ListWithFilters(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("project_id") != "42" {
+			t.Errorf("project_id = %q, want 42", r.URL.Query().Get("project_id"))
+		}
+		if r.URL.Query().Get("authentication_method") != "token" {
+			t.Errorf("authentication_method = %q, want token", r.URL.Query().Get("authentication_method"))
+		}
+		if r.URL.Query().Get("page") != "2" {
+			t.Errorf("page = %q, want 2", r.URL.Query().Get("page"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[],"count":0,"page":2,"per_page":20}`))
+	}))
+	defer srv.Close()
+
+	projectID := 42
+	client := NewHTTPClient(srv.URL, "test-token")
+	servers, err := client.MCPServers().List(context.Background(), &MCPServerListOptions{
+		ProjectID:            &projectID,
+		AuthenticationMethod: "token",
+		Page:                 2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(servers) != 0 {
+		t.Errorf("got %d servers, want 0", len(servers))
+	}
+}
+
+func TestMCPServerService_Get(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/mcp/mcp_servers/mcps-abc" {
+			t.Errorf("path = %s, want /mcp/mcp_servers/mcps-abc", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"id":"mcps-abc","name":"test-server","auth_type":"token","mcp_url":"https://example.com/mcp","tools_count":5,"folder_id":100,"project_id":42,"api_collection":{"id":10,"type":"recipe","name":"my-collection","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"},"folders":[{"id":100,"name":"my-folder"}],"created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	s, err := client.MCPServers().Get(context.Background(), "mcps-abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.ID != "mcps-abc" {
+		t.Errorf("ID = %q, want %q", s.ID, "mcps-abc")
+	}
+	if s.MCPURL != "https://example.com/mcp" {
+		t.Errorf("MCPURL = %q, want %q", s.MCPURL, "https://example.com/mcp")
+	}
+	if s.APICollection == nil || s.APICollection.Name != "my-collection" {
+		t.Errorf("APICollection = %+v, want collection named my-collection", s.APICollection)
+	}
+	if len(s.Folders) != 1 || s.Folders[0].Name != "my-folder" {
+		t.Errorf("Folders = %+v, want 1 folder named my-folder", s.Folders)
+	}
+}
+
+func TestMCPServerService_Create(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/mcp/mcp_servers" {
+			t.Errorf("path = %s, want /mcp/mcp_servers", r.URL.Path)
+		}
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["name"] != "new-server" {
+			t.Errorf("name = %v, want new-server", body["name"])
+		}
+		if body["folder_id"] != float64(100) {
+			t.Errorf("folder_id = %v, want 100", body["folder_id"])
+		}
+		if body["description"] != "test desc" {
+			t.Errorf("description = %v, want test desc", body["description"])
+		}
+		if body["asset_id"] != float64(50) {
+			t.Errorf("asset_id = %v, want 50", body["asset_id"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"id":"mcps-new","name":"new-server","mcp_url":"https://example.com/mcp/new","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	assetID := 50
+	s, err := client.MCPServers().Create(context.Background(), "new-server", 100, "test desc", &assetID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.ID != "mcps-new" {
+		t.Errorf("ID = %q, want %q", s.ID, "mcps-new")
+	}
+	if s.MCPURL != "https://example.com/mcp/new" {
+		t.Errorf("MCPURL = %q, want %q", s.MCPURL, "https://example.com/mcp/new")
+	}
+}
+
+func TestMCPServerService_Update(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/mcp/mcp_servers/mcps-abc" {
+			t.Errorf("path = %s, want /mcp/mcp_servers/mcps-abc", r.URL.Path)
+		}
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["name"] != "renamed" {
+			t.Errorf("name = %v, want renamed", body["name"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"id":"mcps-abc","name":"renamed","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	s, err := client.MCPServers().Update(context.Background(), "mcps-abc", map[string]any{"name": "renamed"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.Name != "renamed" {
+		t.Errorf("Name = %q, want %q", s.Name, "renamed")
+	}
+}
+
+func TestMCPServerService_Delete(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.Path != "/mcp/mcp_servers/mcps-abc" {
+			t.Errorf("path = %s, want /mcp/mcp_servers/mcps-abc", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	err := client.MCPServers().Delete(context.Background(), "mcps-abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMCPServerService_TokenRenew(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/mcp/mcp_servers/mcps-abc/token_renew" {
+			t.Errorf("path = %s, want /mcp/mcp_servers/mcps-abc/token_renew", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"id":"mcps-abc","name":"test-server","mcp_url":"https://example.com/mcp?wkt_token=new-token","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	s, err := client.MCPServers().TokenRenew(context.Background(), "mcps-abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.MCPURL != "https://example.com/mcp?wkt_token=new-token" {
+		t.Errorf("MCPURL = %q, want new-token URL", s.MCPURL)
+	}
+}
+
+func TestMCPServerService_ListTools(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/mcp/mcp_servers/mcps-abc/tools" {
+			t.Errorf("path = %s, want /mcp/mcp_servers/mcps-abc/tools", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		desc := "A test tool"
+		_ = desc
+		w.Write([]byte(`{"items":[{"id":1,"name":"test-tool","description":"A test tool","flow_id":42,"active":true,"enabled":true,"vua_required":false}],"count":1,"page":1,"per_page":100}`))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient(srv.URL, "test-token")
+	tools, err := client.MCPServers().ListTools(context.Background(), "mcps-abc", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("got %d tools, want 1", len(tools))
+	}
+	if tools[0].Name != "test-tool" {
+		t.Errorf("Name = %q, want %q", tools[0].Name, "test-tool")
+	}
+	if tools[0].FlowID != 42 {
+		t.Errorf("FlowID = %d, want 42", tools[0].FlowID)
+	}
+	if !tools[0].Active {
+		t.Error("Active = false, want true")
+	}
+}

--- a/internal/api/recipes.go
+++ b/internal/api/recipes.go
@@ -321,3 +321,12 @@ func (s *recipeService) Connect(ctx context.Context, recipeID int, adapterName s
 	return s.client.do(ctx, "PUT", fmt.Sprintf("/recipes/%d/connect", recipeID), body, nil)
 }
 
+func (s *recipeService) RepeatJobs(ctx context.Context, recipeID int, jobIDs []string) (*RepeatJobsResult, error) {
+	body := map[string]any{"job_ids": jobIDs}
+	var result RepeatJobsResult
+	if err := s.client.do(ctx, "POST", fmt.Sprintf("/recipes/%d/repeat_jobs", recipeID), body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -380,6 +380,18 @@ type JobListOptions struct {
 	Limit  int
 }
 
+// RepeatJobsResult is the response from POST /recipes/:id/repeat_jobs.
+type RepeatJobsResult struct {
+	Results []RepeatJobEntry `json:"results"`
+}
+
+// RepeatJobEntry describes the outcome of a single job repeat request.
+type RepeatJobEntry struct {
+	JobID  string `json:"job_id"`
+	Status string `json:"status"` // "enqueued" or "failed"
+	Error  string `json:"error,omitempty"`
+}
+
 // Connector represents a Workato connector (integration).
 type Connector struct {
 	Name        string `json:"name"`

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -161,29 +161,32 @@ type TagUpdateOptions struct {
 	Color       *string
 }
 
-// APICollection represents a Workato API collection.
+// APICollection represents a Workato API collection. The API does not
+// support description on collections (silently ignored), and project_id
+// is nullable (omitted when the collection has no project association).
 type APICollection struct {
-	ID          int    `json:"id"`
-	Name        string `json:"name"`
-	Handle      string `json:"handle,omitempty"`
-	Version     string `json:"version,omitempty"`
-	Description string `json:"description,omitempty"`
-	UsePrefix   bool   `json:"use_prefix,omitempty"`
-	ProjectID   int    `json:"project_id"`
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	Version    string `json:"version,omitempty"`
+	URL        string `json:"url,omitempty"`
+	APISpecURL string `json:"api_spec_url,omitempty"`
+	ProjectID  *int   `json:"project_id,omitempty"`
 }
 
-// APIEndpoint represents a Workato API endpoint. The create response returns
-// "flow_id" where the list response returns "recipe_id"; FlowID captures the
-// former so both paths decode cleanly.
+// APIEndpoint represents a Workato API endpoint. The API consistently uses
+// "flow_id" for the recipe association (both list and create). RecipeID is
+// backfilled from FlowID for display convenience.
 type APIEndpoint struct {
-	ID              int    `json:"id"`
-	Name            string `json:"name"`
-	APICollectionID int    `json:"api_collection_id"`
-	Active          bool   `json:"active"`
-	Method          string `json:"method,omitempty"`
-	Path            string `json:"path,omitempty"`
-	RecipeID        int    `json:"recipe_id,omitempty"`
-	FlowID          int    `json:"flow_id,omitempty"`
+	ID              int     `json:"id"`
+	Name            string  `json:"name"`
+	APICollectionID int     `json:"api_collection_id"`
+	Active          bool    `json:"active"`
+	Method          string  `json:"method,omitempty"`
+	Path            string  `json:"path,omitempty"`
+	URL             string  `json:"url,omitempty"`
+	FlowID          int     `json:"flow_id,omitempty"`
+	RecipeID        int     `json:"recipe_id,omitempty"`
+	Description     *string `json:"description,omitempty"`
 }
 
 // Skill represents a Workato agentic skill. The API returns string IDs
@@ -202,6 +205,41 @@ type Skill struct {
 	GeniesCount        int    `json:"genies_count"`
 	TriggerDescription string `json:"trigger_description,omitempty"`
 	Applications       []any  `json:"applications,omitempty"`
+}
+
+// APIClient represents a Workato API Platform client (v2 API).
+// The API wraps responses in {"data":...}; unwrapping happens in the service layer.
+type APIClient struct {
+	ID                 int                `json:"id"`
+	Name               string             `json:"name"`
+	AuthType           string             `json:"auth_type,omitempty"`
+	IsLegacy           bool               `json:"is_legacy"`
+	MTLSEnabled        bool               `json:"mtls_enabled"`
+	ActiveAPIKeysCount int                `json:"active_api_keys_count"`
+	TotalAPIKeysCount  int                `json:"total_api_keys_count"`
+	APICollections     []APICollectionRef `json:"api_collections,omitempty"`
+	APIKeys            []APIKey           `json:"api_keys,omitempty"`
+	CreatedAt          time.Time          `json:"created_at"`
+	UpdatedAt          time.Time          `json:"updated_at"`
+}
+
+// APICollectionRef is a lightweight reference to a collection embedded in an API client response.
+type APICollectionRef struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// APIKey represents an API key belonging to an API client (v2 API).
+// AuthToken is only populated on create — subsequent reads omit it.
+type APIKey struct {
+	ID          int      `json:"id"`
+	Name        string   `json:"name"`
+	AuthType    string   `json:"auth_type,omitempty"`
+	AuthToken   string   `json:"auth_token,omitempty"`
+	Active      bool     `json:"active"`
+	ActiveSince *string  `json:"active_since,omitempty"`
+	IPAllowList []string `json:"ip_allow_list,omitempty"`
+	IPDenyList  []string `json:"ip_deny_list,omitempty"`
 }
 
 // PaginationOptions provides generic pagination parameters.

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -264,6 +264,80 @@ type MCPTool struct {
 	Annotations map[string]any `json:"annotations,omitempty"`
 }
 
+// MCPManagedServer is the full detail shape from GET /api/mcp/mcp_servers/:handle.
+// The API wraps responses in {"data":...}; unwrapping happens in the service layer.
+// IDs are strings (e.g. "mcps-AYcNrsC8-Dd8-AB").
+type MCPManagedServer struct {
+	ID                   string                    `json:"id"`
+	Name                 string                    `json:"name"`
+	Description          string                    `json:"description,omitempty"`
+	AssetType            string                    `json:"asset_type,omitempty"`
+	LogoURL              *string                   `json:"logo_url,omitempty"`
+	MCPURL               string                    `json:"mcp_url,omitempty"`
+	AuthType             string                    `json:"auth_type,omitempty"`
+	AuthenticationMethod string                    `json:"authentication_method,omitempty"`
+	FolderID             int                       `json:"folder_id"`
+	ProjectID            int                       `json:"project_id"`
+	Folders              []MCPServerFolder         `json:"folders,omitempty"`
+	HasVUADependentTools bool                      `json:"has_vua_dependent_tools"`
+	IDPUserGroupIDs      []string                  `json:"idp_user_group_ids,omitempty"`
+	APICollection        *MCPServerCollectionRef   `json:"api_collection,omitempty"`
+	ToolsCount           int                       `json:"tools_count"`
+	CreatedAt            time.Time                 `json:"created_at"`
+	UpdatedAt            time.Time                 `json:"updated_at"`
+}
+
+// MCPServerFolder is a lightweight folder reference embedded in an MCP server response.
+type MCPServerFolder struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// MCPServerCollectionRef is the API collection linked to an MCP server.
+type MCPServerCollectionRef struct {
+	ID        int       `json:"id"`
+	Type      string    `json:"type,omitempty"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// MCPServerTool represents a tool assigned to an MCP managed server.
+type MCPServerTool struct {
+	ID                    int      `json:"id"`
+	Name                  string   `json:"name"`
+	Description           *string  `json:"description,omitempty"`
+	OriginalDescription   *string  `json:"original_description,omitempty"`
+	TriggerApplication    *string  `json:"trigger_application,omitempty"`
+	ActionApplications    []string `json:"action_applications,omitempty"`
+	FlowID                int      `json:"flow_id"`
+	Active                bool     `json:"active"`
+	Enabled               bool     `json:"enabled"`
+	VUARequired           bool     `json:"vua_required"`
+	IncompatibilityReasons []string `json:"incompatibility_reasons,omitempty"`
+}
+
+// MCPServerPolicy represents rate/quota limits and IP restrictions for an MCP server.
+type MCPServerPolicy struct {
+	ID          *int              `json:"id"`
+	MCPServerID string            `json:"mcp_server_id"`
+	RateLimits  map[string]int    `json:"rate_limits,omitempty"`
+	QuotaLimits map[string]int    `json:"quota_limits,omitempty"`
+	IPAllowList []string          `json:"ip_allow_list,omitempty"`
+	IPDenyList  []string          `json:"ip_deny_list,omitempty"`
+	CreatedAt   *time.Time        `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time        `json:"updated_at,omitempty"`
+}
+
+// MCPServerListOptions configures MCP server list filtering.
+type MCPServerListOptions struct {
+	ProjectID            *int
+	FolderID             *int
+	AuthenticationMethod string
+	Page                 int
+	PerPage              int
+}
+
 // WorkspaceInfo is the shape returned by GET /users/me. Despite the endpoint
 // path, the response describes the workspace the token authenticates against:
 // id and name are the workspace's. Email is the authenticated account's email.

--- a/internal/api/types_coverage_test.go
+++ b/internal/api/types_coverage_test.go
@@ -192,6 +192,51 @@ func TestStructFieldCoverage(t *testing.T) {
 				"ip_allow_list", "ip_deny_list",
 			},
 		},
+		{
+			name:       "MCPManagedServer",
+			structType: reflect.TypeOf(MCPManagedServer{}),
+			expectedFields: []string{
+				"id", "name", "description", "asset_type", "logo_url",
+				"mcp_url", "auth_type", "authentication_method",
+				"folder_id", "project_id", "folders",
+				"has_vua_dependent_tools", "idp_user_group_ids",
+				"api_collection", "tools_count",
+				"created_at", "updated_at",
+			},
+		},
+		{
+			name:       "MCPServerFolder",
+			structType: reflect.TypeOf(MCPServerFolder{}),
+			expectedFields: []string{
+				"id", "name",
+			},
+		},
+		{
+			name:       "MCPServerCollectionRef",
+			structType: reflect.TypeOf(MCPServerCollectionRef{}),
+			expectedFields: []string{
+				"id", "type", "name", "created_at", "updated_at",
+			},
+		},
+		{
+			name:       "MCPServerTool",
+			structType: reflect.TypeOf(MCPServerTool{}),
+			expectedFields: []string{
+				"id", "name", "description", "original_description",
+				"trigger_application", "action_applications",
+				"flow_id", "active", "enabled", "vua_required",
+				"incompatibility_reasons",
+			},
+		},
+		{
+			name:       "MCPServerPolicy",
+			structType: reflect.TypeOf(MCPServerPolicy{}),
+			expectedFields: []string{
+				"id", "mcp_server_id", "rate_limits", "quota_limits",
+				"ip_allow_list", "ip_deny_list",
+				"created_at", "updated_at",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -242,7 +287,9 @@ func TestStructFieldCoverage_TableColumns(t *testing.T) {
 		"AuditLogEntry": {"id", "event_type", "user", "timestamp"},
 		"Connector":     {"name", "title", "description"},
 		"Skill":         {"id", "name", "provider_id", "folder_id", "project_id", "running"},
-		"APIClient":     {"id", "name", "auth_type", "api_collections", "active_api_keys_count"},
+		"APIClient":          {"id", "name", "auth_type", "api_collections", "active_api_keys_count"},
+		"MCPManagedServer":   {"id", "name", "auth_type", "tools_count", "project_id", "folder_id"},
+		"MCPServerTool":      {"id", "name", "description", "flow_id", "active"},
 	}
 
 	structTypes := map[string]reflect.Type{
@@ -255,8 +302,10 @@ func TestStructFieldCoverage_TableColumns(t *testing.T) {
 		"WorkspaceUser": reflect.TypeOf(WorkspaceUser{}),
 		"AuditLogEntry": reflect.TypeOf(AuditLogEntry{}),
 		"Connector":     reflect.TypeOf(Connector{}),
-		"Skill":         reflect.TypeOf(Skill{}),
-		"APIClient":     reflect.TypeOf(APIClient{}),
+		"Skill":             reflect.TypeOf(Skill{}),
+		"APIClient":         reflect.TypeOf(APIClient{}),
+		"MCPManagedServer":  reflect.TypeOf(MCPManagedServer{}),
+		"MCPServerTool":     reflect.TypeOf(MCPServerTool{}),
 	}
 
 	for name, fields := range requiredTableFields {

--- a/internal/api/types_coverage_test.go
+++ b/internal/api/types_coverage_test.go
@@ -83,8 +83,8 @@ func TestStructFieldCoverage(t *testing.T) {
 			name:       "APICollection",
 			structType: reflect.TypeOf(APICollection{}),
 			expectedFields: []string{
-				"id", "name", "handle", "version",
-				"description", "use_prefix", "project_id",
+				"id", "name", "version", "url",
+				"api_spec_url", "project_id",
 			},
 		},
 		{
@@ -92,7 +92,8 @@ func TestStructFieldCoverage(t *testing.T) {
 			structType: reflect.TypeOf(APIEndpoint{}),
 			expectedFields: []string{
 				"id", "name", "api_collection_id", "active",
-				"method", "path", "recipe_id", "flow_id",
+				"method", "path", "url", "flow_id",
+				"recipe_id", "description",
 			},
 		},
 		{
@@ -165,6 +166,32 @@ func TestStructFieldCoverage(t *testing.T) {
 				"genies_count", "trigger_description", "applications",
 			},
 		},
+		{
+			name:       "APIClient",
+			structType: reflect.TypeOf(APIClient{}),
+			expectedFields: []string{
+				"id", "name", "auth_type", "is_legacy", "mtls_enabled",
+				"active_api_keys_count", "total_api_keys_count",
+				"api_collections", "api_keys",
+				"created_at", "updated_at",
+			},
+		},
+		{
+			name:       "APICollectionRef",
+			structType: reflect.TypeOf(APICollectionRef{}),
+			expectedFields: []string{
+				"id", "name",
+			},
+		},
+		{
+			name:       "APIKey",
+			structType: reflect.TypeOf(APIKey{}),
+			expectedFields: []string{
+				"id", "name", "auth_type", "auth_token",
+				"active", "active_since",
+				"ip_allow_list", "ip_deny_list",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -208,13 +235,14 @@ func TestStructFieldCoverage_TableColumns(t *testing.T) {
 		"Recipe":        {"id", "name", "description", "folder_id", "running", "version"},
 		"Connection":    {"id", "name", "application", "folder_id", "authorization_status"},
 		"Folder":        {"id", "name", "parent_id"},
-		"APICollection": {"id", "name", "handle", "version", "description", "project_id"},
-		"APIEndpoint":   {"id", "name", "method", "path", "recipe_id", "api_collection_id", "active"},
+		"APICollection": {"id", "name", "version", "url", "project_id"},
+		"APIEndpoint":   {"id", "name", "method", "path", "flow_id", "api_collection_id", "active"},
 		"Tag":           {"handle", "title", "description", "color"},
 		"WorkspaceUser": {"id", "name", "email"},
 		"AuditLogEntry": {"id", "event_type", "user", "timestamp"},
 		"Connector":     {"name", "title", "description"},
 		"Skill":         {"id", "name", "provider_id", "folder_id", "project_id", "running"},
+		"APIClient":     {"id", "name", "auth_type", "api_collections", "active_api_keys_count"},
 	}
 
 	structTypes := map[string]reflect.Type{
@@ -228,6 +256,7 @@ func TestStructFieldCoverage_TableColumns(t *testing.T) {
 		"AuditLogEntry": reflect.TypeOf(AuditLogEntry{}),
 		"Connector":     reflect.TypeOf(Connector{}),
 		"Skill":         reflect.TypeOf(Skill{}),
+		"APIClient":     reflect.TypeOf(APIClient{}),
 	}
 
 	for name, fields := range requiredTableFields {

--- a/internal/api/workspace.go
+++ b/internal/api/workspace.go
@@ -35,6 +35,27 @@ func (s *workspaceService) ListMembers(ctx context.Context, email string) ([]Wor
 	return wrapper.Data, nil
 }
 
+func (s *workspaceService) ListProperties(ctx context.Context, prefix string) (map[string]string, error) {
+	params := url.Values{}
+	if prefix != "" {
+		params.Set("prefix", prefix)
+	}
+	path := "/properties"
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+	var result map[string]string
+	if err := s.client.do(ctx, "GET", path, nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (s *workspaceService) SetProperties(ctx context.Context, properties map[string]string) error {
+	body := map[string]any{"properties": properties}
+	return s.client.do(ctx, "POST", "/properties", body, nil)
+}
+
 func (s *workspaceService) GetAuditLogs(ctx context.Context, opts *AuditLogOptions) ([]AuditLogEntry, error) {
 	params := url.Values{}
 	if opts != nil {

--- a/internal/commands/api.go
+++ b/internal/commands/api.go
@@ -2,10 +2,13 @@ package commands
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -166,6 +169,7 @@ func newAPIEndpointsCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newAPIEndpointsListCmd())
 	cmd.AddCommand(newAPIEndpointsCreateCmd())
+	cmd.AddCommand(newAPIEndpointsCreateBatchCmd())
 	cmd.AddCommand(newAPIEndpointsEnableCmd())
 	cmd.AddCommand(newAPIEndpointsDisableCmd())
 	return cmd
@@ -294,6 +298,247 @@ or recipe_name (resolved to flow_id via recipe lookup).`,
 	cmd.Flags().IntVar(&collectionID, "collection", 0, "API collection ID")
 	_ = cmd.MarkFlagRequired("collection")
 	return cmd
+}
+
+func newAPIEndpointsCreateBatchCmd() *cobra.Command {
+	var collectionID int
+	var fromCSV string
+	var dryRun, continueOnError bool
+
+	cmd := &cobra.Command{
+		Use:   "create-batch <directory>",
+		Short: "Create API endpoints in batch from a directory or CSV",
+		Long: `Create multiple API endpoints from JSON definition files or a CSV file.
+
+Directory mode: reads all *.api_endpoint.json files from the given directory.
+CSV mode: reads a CSV file with columns: collection,recipe_name,display_name,method,path,description
+
+In both modes, recipe_name is resolved to flow_id via recipe lookup.`,
+		Example: `  wk api endpoints create-batch ./definitions/ --collection 42
+  wk api endpoints create-batch --from-csv endpoints.csv --collection 42
+  wk api endpoints create-batch --from-csv endpoints.csv
+  wk api endpoints create-batch ./definitions/ --collection 42 --dry-run`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			var entries []batchEntry
+
+			if fromCSV != "" {
+				csvEntries, err := parseEndpointCSV(cmd.Context(), client, fromCSV, collectionID, cmd.Flags().Changed("collection"))
+				if err != nil {
+					return err
+				}
+				entries = csvEntries
+			} else {
+				if len(args) == 0 {
+					return fmt.Errorf("directory path is required, or use --from-csv")
+				}
+				if !cmd.Flags().Changed("collection") {
+					return fmt.Errorf("--collection is required in directory mode")
+				}
+				dirEntries, err := parseEndpointDir(args[0])
+				if err != nil {
+					return err
+				}
+				for _, de := range dirEntries {
+					entries = append(entries, batchEntry{Source: de.Source, Data: de.Data, CollID: collectionID})
+				}
+			}
+
+			if len(entries) == 0 {
+				return fmt.Errorf("no endpoint definitions found")
+			}
+
+			type resultEntry struct {
+				Name   string `json:"name"`
+				ID     int    `json:"id,omitempty"`
+				Source string `json:"source"`
+				Error  string `json:"error,omitempty"`
+			}
+
+			var created, failed []resultEntry
+
+			for _, e := range entries {
+				var parsed map[string]any
+				_ = json.Unmarshal(e.Data, &parsed)
+				name, _ := parsed["name"].(string)
+				if name == "" {
+					name = e.Source
+				}
+
+				if dryRun {
+					fmt.Fprintf(os.Stderr, "[dry-run] would create: %s (collection %d)\n", name, e.CollID)
+					continue
+				}
+
+				data, err := resolveRecipeNameInEndpointJSON(cmd.Context(), client, e.Data)
+				if err != nil {
+					if continueOnError {
+						fmt.Fprintf(os.Stderr, "FAIL  %s: %v\n", e.Source, err)
+						failed = append(failed, resultEntry{Name: name, Source: e.Source, Error: err.Error()})
+						continue
+					}
+					return fmt.Errorf("%s: %w", e.Source, err)
+				}
+
+				ep, err := client.APIEndpoints().Create(cmd.Context(), e.CollID, data)
+				if err != nil {
+					if continueOnError {
+						fmt.Fprintf(os.Stderr, "FAIL  %s: %v\n", e.Source, err)
+						failed = append(failed, resultEntry{Name: name, Source: e.Source, Error: err.Error()})
+						continue
+					}
+					return fmt.Errorf("%s: %w", e.Source, err)
+				}
+
+				fmt.Fprintf(os.Stderr, "OK    %s (ID: %d)\n", ep.Name, ep.ID)
+				created = append(created, resultEntry{Name: ep.Name, ID: ep.ID, Source: e.Source})
+			}
+
+			if dryRun {
+				fmt.Fprintf(os.Stderr, "\n%d endpoint(s) would be created\n", len(entries))
+				return nil
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, map[string]any{
+					"created": created,
+					"failed":  failed,
+				})
+			}
+
+			fmt.Fprintf(os.Stderr, "\n%d created, %d failed\n", len(created), len(failed))
+			if len(failed) > 0 {
+				return fmt.Errorf("batch completed with %d error(s)", len(failed))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&collectionID, "collection", 0, "API collection ID (required for directory mode; default for CSV rows)")
+	cmd.Flags().StringVar(&fromCSV, "from-csv", "", "Read endpoint definitions from a CSV file")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be created without making API calls")
+	cmd.Flags().BoolVar(&continueOnError, "continue-on-error", false, "Continue creating remaining endpoints if one fails")
+	return cmd
+}
+
+type dirEntry struct {
+	Source string
+	Data   []byte
+}
+
+func parseEndpointDir(dir string) ([]dirEntry, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.api_endpoint.json"))
+	if err != nil {
+		return nil, fmt.Errorf("scanning directory: %w", err)
+	}
+	if len(matches) == 0 {
+		matches, err = filepath.Glob(filepath.Join(dir, "*.json"))
+		if err != nil {
+			return nil, fmt.Errorf("scanning directory: %w", err)
+		}
+	}
+	var entries []dirEntry
+	for _, path := range matches {
+		if strings.HasSuffix(filepath.Base(path), "api_collection.json") {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", path, err)
+		}
+		entries = append(entries, dirEntry{Source: filepath.Base(path), Data: data})
+	}
+	return entries, nil
+}
+
+type batchEntry struct {
+	Source string
+	Data   []byte
+	CollID int
+}
+
+func parseEndpointCSV(ctx context.Context, client api.Client, csvPath string, defaultCollID int, hasDefaultColl bool) ([]batchEntry, error) {
+	f, err := os.Open(csvPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening CSV: %w", err)
+	}
+	defer f.Close()
+
+	reader := csv.NewReader(f)
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("parsing CSV: %w", err)
+	}
+	if len(records) < 2 {
+		return nil, fmt.Errorf("CSV must have a header row and at least one data row")
+	}
+
+	header := records[0]
+	colIdx := make(map[string]int)
+	for i, h := range header {
+		colIdx[strings.TrimSpace(strings.ToLower(h))] = i
+	}
+
+	requiredCols := []string{"recipe_name", "display_name", "method", "path"}
+	for _, col := range requiredCols {
+		if _, ok := colIdx[col]; !ok {
+			return nil, fmt.Errorf("CSV missing required column %q (have: %s)", col, strings.Join(header, ", "))
+		}
+	}
+
+	collectionCache := make(map[string]int)
+
+	var entries []batchEntry
+	for i, row := range records[1:] {
+		rowNum := i + 2
+
+		collID := defaultCollID
+		if collColIdx, ok := colIdx["collection"]; ok && !hasDefaultColl {
+			collName := strings.TrimSpace(row[collColIdx])
+			if collName != "" {
+				if cached, ok := collectionCache[collName]; ok {
+					collID = cached
+				} else {
+					resolved, err := resolveCollectionName(ctx, client, collName)
+					if err != nil {
+						return nil, fmt.Errorf("row %d: %w", rowNum, err)
+					}
+					collectionCache[collName] = resolved
+					collID = resolved
+				}
+			}
+		}
+		if collID == 0 {
+			return nil, fmt.Errorf("row %d: no collection ID — provide --collection or include a 'collection' column", rowNum)
+		}
+
+		ep := map[string]any{
+			"name":        strings.TrimSpace(row[colIdx["display_name"]]),
+			"method":      strings.TrimSpace(row[colIdx["method"]]),
+			"path":        strings.TrimSpace(row[colIdx["path"]]),
+			"recipe_name": strings.TrimSpace(row[colIdx["recipe_name"]]),
+		}
+		if descIdx, ok := colIdx["description"]; ok && descIdx < len(row) {
+			desc := strings.TrimSpace(row[descIdx])
+			if desc != "" {
+				ep["description"] = desc
+			}
+		}
+
+		data, _ := json.Marshal(ep)
+		source := fmt.Sprintf("%s:%d", filepath.Base(csvPath), rowNum)
+		entries = append(entries, batchEntry{Source: source, Data: data, CollID: collID})
+	}
+
+	return entries, nil
 }
 
 func newAPIEndpointsEnableCmd() *cobra.Command {
@@ -655,9 +900,39 @@ The previous token is immediately invalidated.`,
 	}
 }
 
+// resolveCollectionName resolves an API collection name to its ID.
+func resolveCollectionName(ctx context.Context, client api.Client, name string) (int, error) {
+	collections, err := client.APICollections().List(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("listing collections: %w", err)
+	}
+	var matches []api.APICollection
+	for _, c := range collections {
+		if c.Name == name {
+			matches = append(matches, c)
+		}
+	}
+	if len(matches) == 0 {
+		return 0, fmt.Errorf("no collection found with name %q", name)
+	}
+	if len(matches) > 1 {
+		return 0, fmt.Errorf("multiple collections match name %q (%d found); use collection ID instead", name, len(matches))
+	}
+	return matches[0].ID, nil
+}
+
+// normalizeRecipeName lowercases and replaces underscores with spaces
+// so that slug-style names ("check_in_guest") match display names
+// ("Check in guest") in portable definition files.
+func normalizeRecipeName(s string) string {
+	return strings.ToLower(strings.ReplaceAll(s, "_", " "))
+}
+
 // resolveRecipeNameInEndpointJSON checks if the JSON body contains
 // "recipe_name" and resolves it to "flow_id" via recipe list lookup.
-// Returns the modified JSON with flow_id set and recipe_name removed.
+// Tries exact match first, then normalized match (case-insensitive,
+// underscores treated as spaces). Returns the modified JSON with
+// flow_id set and recipe_name removed.
 func resolveRecipeNameInEndpointJSON(ctx context.Context, client api.Client, data []byte) ([]byte, error) {
 	var body map[string]any
 	if err := json.Unmarshal(data, &body); err != nil {
@@ -678,12 +953,24 @@ func resolveRecipeNameInEndpointJSON(ctx context.Context, client api.Client, dat
 		return nil, fmt.Errorf("looking up recipe %q: %w", recipeName, err)
 	}
 
+	// Exact match first.
 	var matches []api.Recipe
 	for _, r := range recipes {
 		if r.Name == recipeName {
 			matches = append(matches, r)
 		}
 	}
+
+	// Normalized match if no exact match found.
+	if len(matches) == 0 {
+		norm := normalizeRecipeName(recipeName)
+		for _, r := range recipes {
+			if normalizeRecipeName(r.Name) == norm {
+				matches = append(matches, r)
+			}
+		}
+	}
+
 	if len(matches) == 0 {
 		return nil, fmt.Errorf("no recipe found with name %q", recipeName)
 	}

--- a/internal/commands/api.go
+++ b/internal/commands/api.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -18,6 +20,7 @@ func newAPICmd() *cobra.Command {
 	}
 	cmd.AddCommand(newAPICollectionsCmd())
 	cmd.AddCommand(newAPIEndpointsCmd())
+	cmd.AddCommand(newAPIClientsCmd())
 	return cmd
 }
 
@@ -56,16 +59,19 @@ func newAPICollectionsListCmd() *cobra.Command {
 				return err
 			}
 
-			headers := []string{"ID", "NAME", "HANDLE", "VERSION", "DESCRIPTION", "PROJECT ID"}
+			headers := []string{"ID", "NAME", "VERSION", "URL", "PROJECT ID"}
 			var rows [][]string
 			for _, c := range collections {
+				pid := ""
+				if c.ProjectID != nil {
+					pid = strconv.Itoa(*c.ProjectID)
+				}
 				rows = append(rows, []string{
 					strconv.Itoa(c.ID),
 					c.Name,
-					c.Handle,
 					c.Version,
-					c.Description,
-					strconv.Itoa(c.ProjectID),
+					c.URL,
+					pid,
 				})
 			}
 			meta := output.PageMeta{Page: page, PerPage: perPage, HasNext: perPage > 0 && len(collections) == perPage}
@@ -81,11 +87,18 @@ func newAPICollectionsListCmd() *cobra.Command {
 func newAPICollectionsCreateCmd() *cobra.Command {
 	var name string
 	var projectID int
+	var fromFile string
 
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create an API collection",
-		Example: `  wk api collections create --name "Customer API" --project 123 --json`,
+		Long: `Create an API collection.
+
+When --from-file is used, the JSON file provides the collection name.
+Flags (--name, --project) override file values.`,
+		Example: `  wk api collections create --name "Customer API" --json
+  wk api collections create --name "Customer API" --project 123 --json
+  wk api collections create --from-file collection.json --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rctx, err := BuildRunContext(cmd)
 			if err != nil {
@@ -96,7 +109,36 @@ func newAPICollectionsCreateCmd() *cobra.Command {
 				return err
 			}
 
-			collection, err := client.APICollections().Create(cmd.Context(), name, projectID)
+			if fromFile != "" {
+				data, ferr := os.ReadFile(fromFile)
+				if ferr != nil {
+					return fmt.Errorf("reading file: %w", ferr)
+				}
+				var fileDef struct {
+					Name      string `json:"name"`
+					ProjectID *int   `json:"project_id,omitempty"`
+				}
+				if jerr := json.Unmarshal(data, &fileDef); jerr != nil {
+					return fmt.Errorf("invalid JSON: %w", jerr)
+				}
+				if name == "" {
+					name = fileDef.Name
+				}
+				if !cmd.Flags().Changed("project") && fileDef.ProjectID != nil {
+					projectID = *fileDef.ProjectID
+				}
+			}
+
+			if name == "" {
+				return fmt.Errorf("--name is required (or use --from-file with a JSON file containing \"name\")")
+			}
+
+			var pid *int
+			if cmd.Flags().Changed("project") || projectID != 0 {
+				pid = &projectID
+			}
+
+			collection, err := client.APICollections().Create(cmd.Context(), name, pid)
 			if err != nil {
 				return err
 			}
@@ -112,8 +154,7 @@ func newAPICollectionsCreateCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&name, "name", "", "Collection name")
 	cmd.Flags().IntVar(&projectID, "project", 0, "Project ID")
-	_ = cmd.MarkFlagRequired("name")
-	_ = cmd.MarkFlagRequired("project")
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "JSON file with collection definition")
 	return cmd
 }
 
@@ -171,7 +212,7 @@ func newAPIEndpointsListCmd() *cobra.Command {
 					e.Name,
 					e.Method,
 					e.Path,
-					strconv.Itoa(e.RecipeID),
+					strconv.Itoa(e.FlowID),
 					strconv.Itoa(e.APICollectionID),
 					active,
 				})
@@ -195,7 +236,8 @@ func newAPIEndpointsCreateCmd() *cobra.Command {
 		Short: "Create an API endpoint from a JSON file",
 		Long: `Create an API endpoint from a JSON definition file.
 
-The file should contain: name, method, path, and flow_id (recipe ID).`,
+The file should contain: name, method, path, and either flow_id (recipe ID)
+or recipe_name (resolved to flow_id via recipe lookup).`,
 		Example: `  wk api endpoints create endpoint.json --collection 42
   wk api endpoints create endpoint.json --collection 42 --json`,
 		Args: requireArgs(1, "file path is required, e.g.: wk api endpoints create <path> --collection <id>"),
@@ -214,6 +256,11 @@ The file should contain: name, method, path, and flow_id (recipe ID).`,
 				return fmt.Errorf("reading file: %w", err)
 			}
 
+			data, err = resolveRecipeNameInEndpointJSON(cmd.Context(), client, data)
+			if err != nil {
+				return err
+			}
+
 			ep, err := client.APIEndpoints().Create(cmd.Context(), collectionID, data)
 			if err != nil {
 				return err
@@ -228,7 +275,13 @@ The file should contain: name, method, path, and flow_id (recipe ID).`,
 			fmt.Fprintf(os.Stdout, "Method:        %s\n", ep.Method)
 			fmt.Fprintf(os.Stdout, "Path:          %s\n", ep.Path)
 			fmt.Fprintf(os.Stdout, "Collection ID: %d\n", ep.APICollectionID)
-			fmt.Fprintf(os.Stdout, "Recipe ID:     %d\n", ep.RecipeID)
+			fmt.Fprintf(os.Stdout, "Recipe ID:     %d\n", ep.FlowID)
+			if ep.URL != "" {
+				fmt.Fprintf(os.Stdout, "URL:           %s\n", ep.URL)
+			}
+			if ep.Description != nil && *ep.Description != "" {
+				fmt.Fprintf(os.Stdout, "Description:   %s\n", *ep.Description)
+			}
 			active := "no"
 			if ep.Active {
 				active = "yes"
@@ -295,5 +348,351 @@ func newAPIEndpointsDisableCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func newAPIClientsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "clients",
+		Aliases: []string{"client"},
+		Short:   "Manage API Platform clients",
+	}
+	cmd.AddCommand(newAPIClientsListCmd())
+	cmd.AddCommand(newAPIClientsGetCmd())
+	cmd.AddCommand(newAPIClientsCreateCmd())
+	cmd.AddCommand(newAPIClientsDeleteCmd())
+	cmd.AddCommand(newAPIClientsKeysCmd())
+	return cmd
+}
+
+func newAPIClientsListCmd() *cobra.Command {
+	var page, perPage int
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List API Platform clients",
+		Example: `  wk api clients list
+  wk api clients list --page 1 --per-page 20 --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			opts := &api.PaginationOptions{Page: page, PerPage: perPage}
+			clients, err := client.APIClients().List(cmd.Context(), opts)
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"ID", "NAME", "AUTH TYPE", "COLLECTIONS", "ACTIVE KEYS"}
+			var rows [][]string
+			for _, c := range clients {
+				var colNames []string
+				for _, col := range c.APICollections {
+					colNames = append(colNames, col.Name)
+				}
+				collections := ""
+				if len(colNames) > 0 {
+					collections = fmt.Sprintf("%v", colNames)
+				}
+				rows = append(rows, []string{
+					strconv.Itoa(c.ID),
+					c.Name,
+					c.AuthType,
+					collections,
+					strconv.Itoa(c.ActiveAPIKeysCount),
+				})
+			}
+			meta := output.PageMeta{Page: page, PerPage: perPage, HasNext: perPage > 0 && len(clients) == perPage}
+			return rctx.Formatter.FormatPage(os.Stdout, clients, headers, rows, meta)
+		},
+	}
+
+	cmd.Flags().IntVar(&page, "page", 0, "Page number")
+	cmd.Flags().IntVar(&perPage, "per-page", 0, "Items per page")
+	return cmd
+}
+
+func newAPIClientsGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Get an API Platform client",
+		Example: `  wk api clients get 42
+  wk api clients get 42 --json`,
+		Args: requireArgs(1, "client ID is required, e.g.: wk api clients get <id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid client ID: %s", args[0])
+			}
+
+			ac, err := client.APIClients().Get(cmd.Context(), id)
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, ac)
+			}
+
+			fmt.Fprintf(os.Stdout, "ID:          %d\n", ac.ID)
+			fmt.Fprintf(os.Stdout, "Name:        %s\n", ac.Name)
+			fmt.Fprintf(os.Stdout, "Auth Type:   %s\n", ac.AuthType)
+			fmt.Fprintf(os.Stdout, "Legacy:      %v\n", ac.IsLegacy)
+			fmt.Fprintf(os.Stdout, "mTLS:        %v\n", ac.MTLSEnabled)
+			fmt.Fprintf(os.Stdout, "Active Keys: %d\n", ac.ActiveAPIKeysCount)
+			fmt.Fprintf(os.Stdout, "Total Keys:  %d\n", ac.TotalAPIKeysCount)
+			if len(ac.APICollections) > 0 {
+				fmt.Fprintf(os.Stdout, "Collections:\n")
+				for _, col := range ac.APICollections {
+					fmt.Fprintf(os.Stdout, "  - %s (ID: %d)\n", col.Name, col.ID)
+				}
+			}
+			if len(ac.APIKeys) > 0 {
+				fmt.Fprintf(os.Stdout, "Keys:\n")
+				for _, k := range ac.APIKeys {
+					active := "inactive"
+					if k.Active {
+						active = "active"
+					}
+					fmt.Fprintf(os.Stdout, "  - %s (ID: %d, %s)\n", k.Name, k.ID, active)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func newAPIClientsCreateCmd() *cobra.Command {
+	var name, authType string
+	var collections []string
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an API Platform client",
+		Example: `  wk api clients create --name "My Client" --collections 42,43
+  wk api clients create --name "My Client" --auth-type token --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			if name == "" {
+				return fmt.Errorf("--name is required")
+			}
+
+			if authType == "" {
+				authType = "token"
+			}
+
+			ac, err := client.APIClients().Create(cmd.Context(), name, collections, authType)
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, ac)
+			}
+
+			fmt.Fprintf(os.Stderr, "Created API client %q (ID: %d)\n", ac.Name, ac.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Client name")
+	cmd.Flags().StringSliceVar(&collections, "collections", nil, "API collection IDs (as strings, e.g. 42,43)")
+	cmd.Flags().StringVar(&authType, "auth-type", "token", "Authentication type")
+	return cmd
+}
+
+func newAPIClientsDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete <id>",
+		Short:   "Delete an API Platform client",
+		Example: `  wk api clients delete 42`,
+		Args:    requireArgs(1, "client ID is required, e.g.: wk api clients delete <id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			id, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid client ID: %s", args[0])
+			}
+
+			if err := client.APIClients().Delete(cmd.Context(), id); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(os.Stderr, "Deleted API client %d\n", id)
+			return nil
+		},
+	}
+}
+
+func newAPIClientsKeysCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "keys",
+		Aliases: []string{"key"},
+		Short:   "Manage API client keys",
+	}
+	cmd.AddCommand(newAPIClientsKeysCreateCmd())
+	cmd.AddCommand(newAPIClientsKeysRefreshCmd())
+	return cmd
+}
+
+func newAPIClientsKeysCreateCmd() *cobra.Command {
+	var name string
+
+	cmd := &cobra.Command{
+		Use:   "create <client-id>",
+		Short: "Create an API key for a client",
+		Long: `Create an API key for a client. The auth token is printed to stdout
+and is only visible at creation time — it cannot be retrieved later.`,
+		Example: `  wk api clients keys create 42 --name "prod-key"
+  wk api clients keys create 42 --name "prod-key" --json`,
+		Args: requireArgs(1, "client ID is required, e.g.: wk api clients keys create <client-id> --name <name>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			clientID, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid client ID: %s", args[0])
+			}
+
+			if name == "" {
+				return fmt.Errorf("--name is required")
+			}
+
+			key, err := client.APIClients().CreateKey(cmd.Context(), clientID, name)
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, key)
+			}
+
+			fmt.Fprintf(os.Stderr, "Created API key %q (ID: %d) for client %d\n", key.Name, key.ID, clientID)
+			fmt.Fprintln(os.Stdout, key.AuthToken)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Key name")
+	return cmd
+}
+
+func newAPIClientsKeysRefreshCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "refresh <client-id> <key-id>",
+		Short: "Rotate an API key (generates a new auth token)",
+		Long: `Rotate an API key, generating a new auth token. The new token is printed
+to stdout and is only visible at this moment — it cannot be retrieved later.
+The previous token is immediately invalidated.`,
+		Example: `  wk api clients keys refresh 42 10
+  wk api clients keys refresh 42 10 --json`,
+		Args: requireArgs(2, "client ID and key ID are required, e.g.: wk api clients keys refresh <client-id> <key-id>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			clientID, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid client ID: %s", args[0])
+			}
+			keyID, err := strconv.Atoi(args[1])
+			if err != nil {
+				return fmt.Errorf("invalid key ID: %s", args[1])
+			}
+
+			key, err := client.APIClients().RefreshKey(cmd.Context(), clientID, keyID)
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, key)
+			}
+
+			fmt.Fprintf(os.Stderr, "Rotated API key %q (ID: %d) for client %d\n", key.Name, key.ID, clientID)
+			fmt.Fprintln(os.Stdout, key.AuthToken)
+			return nil
+		},
+	}
+}
+
+// resolveRecipeNameInEndpointJSON checks if the JSON body contains
+// "recipe_name" and resolves it to "flow_id" via recipe list lookup.
+// Returns the modified JSON with flow_id set and recipe_name removed.
+func resolveRecipeNameInEndpointJSON(ctx context.Context, client api.Client, data []byte) ([]byte, error) {
+	var body map[string]any
+	if err := json.Unmarshal(data, &body); err != nil {
+		return data, nil
+	}
+
+	recipeName, hasName := body["recipe_name"].(string)
+	_, hasFlowID := body["flow_id"]
+	if !hasName {
+		return data, nil
+	}
+	if hasFlowID {
+		return nil, fmt.Errorf("cannot specify both flow_id and recipe_name")
+	}
+
+	recipes, err := client.Recipes().List(ctx, &api.RecipeListOptions{PerPage: 100})
+	if err != nil {
+		return nil, fmt.Errorf("looking up recipe %q: %w", recipeName, err)
+	}
+
+	var matches []api.Recipe
+	for _, r := range recipes {
+		if r.Name == recipeName {
+			matches = append(matches, r)
+		}
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no recipe found with name %q", recipeName)
+	}
+	if len(matches) > 1 {
+		return nil, fmt.Errorf("multiple recipes match name %q (%d found); use flow_id instead", recipeName, len(matches))
+	}
+
+	body["flow_id"] = matches[0].ID
+	delete(body, "recipe_name")
+	return json.Marshal(body)
 }
 

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -290,8 +290,7 @@ func newAuthStatusCmd() *cobra.Command {
 				return err
 			}
 
-			pm := auth.NewProfileManager()
-			activeName, err := pm.GetActiveProfile()
+			activeName, _, err := resolveActiveProfileName()
 			if err != nil {
 				return fmt.Errorf("no active profile: %w", err)
 			}
@@ -301,6 +300,7 @@ func newAuthStatusCmd() *cobra.Command {
 				// Fall back to metadata-only read so status can still report
 				// which profile is configured even if the backend can't be
 				// reached.
+				pm := auth.NewProfileManager()
 				p, perr := pm.GetProfile(activeName)
 				if perr != nil {
 					return fmt.Errorf("profile %q: %w", activeName, perr)

--- a/internal/commands/clone.go
+++ b/internal/commands/clone.go
@@ -93,7 +93,7 @@ pull/push/diff calls skip the folder-hierarchy lookup.`,
 			// Create sync engine and pull
 			engine := sync.NewSyncEngine(absPath, cfg, client)
 			entry := cfg.Sync[0]
-			results, err := engine.Pull(entry, true) // force=true since fresh clone
+			results, err := engine.Pull(entry, true, false) // force=true since fresh clone
 			if err != nil {
 				return fmt.Errorf("pulling assets: %w", err)
 			}

--- a/internal/commands/mcp.go
+++ b/internal/commands/mcp.go
@@ -17,6 +17,7 @@ func newMCPCmd() *cobra.Command {
 	}
 	cmd.AddCommand(newMCPTestCmd())
 	cmd.AddCommand(newMCPToolsCmd())
+	cmd.AddCommand(newMCPServersCmd())
 	return cmd
 }
 

--- a/internal/commands/mcp_servers.go
+++ b/internal/commands/mcp_servers.go
@@ -1,0 +1,598 @@
+package commands
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/workato-devs/wk-cli-beta/internal/api"
+	"github.com/workato-devs/wk-cli-beta/internal/output"
+)
+
+func newMCPServersCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "servers",
+		Aliases: []string{"server"},
+		Short:   "Manage MCP servers in the workspace",
+	}
+	cmd.AddCommand(newMCPServersListCmd())
+	cmd.AddCommand(newMCPServersGetCmd())
+	cmd.AddCommand(newMCPServersCreateCmd())
+	cmd.AddCommand(newMCPServersCreateBatchCmd())
+	cmd.AddCommand(newMCPServersUpdateCmd())
+	cmd.AddCommand(newMCPServersDeleteCmd())
+	cmd.AddCommand(newMCPServersTokenRenewCmd())
+	cmd.AddCommand(newMCPServersToolsCmd())
+	return cmd
+}
+
+func newMCPServersListCmd() *cobra.Command {
+	var page, perPage int
+	var projectID, folderID int
+	var authMethod string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List MCP servers",
+		Example: `  wk mcp servers list
+  wk mcp servers list --project-id 42
+  wk mcp servers list --auth-method token --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			opts := &api.MCPServerListOptions{
+				AuthenticationMethod: authMethod,
+				Page:                 page,
+				PerPage:              perPage,
+			}
+			if cmd.Flags().Changed("project-id") {
+				opts.ProjectID = &projectID
+			}
+			if cmd.Flags().Changed("folder-id") {
+				opts.FolderID = &folderID
+			}
+
+			servers, err := client.MCPServers().List(cmd.Context(), opts)
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"ID", "NAME", "AUTH", "TOOLS", "PROJECT", "FOLDER"}
+			var rows [][]string
+			for _, s := range servers {
+				auth := s.AuthenticationMethod
+				if auth == "" {
+					auth = s.AuthType
+				}
+				rows = append(rows, []string{
+					s.ID,
+					s.Name,
+					auth,
+					strconv.Itoa(s.ToolsCount),
+					strconv.Itoa(s.ProjectID),
+					strconv.Itoa(s.FolderID),
+				})
+			}
+			meta := output.PageMeta{Page: page, PerPage: perPage, HasNext: perPage > 0 && len(servers) == perPage}
+			return rctx.Formatter.FormatPage(os.Stdout, servers, headers, rows, meta)
+		},
+	}
+
+	cmd.Flags().IntVar(&page, "page", 0, "Page number")
+	cmd.Flags().IntVar(&perPage, "per-page", 0, "Items per page (max 50)")
+	cmd.Flags().IntVar(&projectID, "project-id", 0, "Filter by project ID")
+	cmd.Flags().IntVar(&folderID, "folder-id", 0, "Filter by folder ID")
+	cmd.Flags().StringVar(&authMethod, "auth-method", "", "Filter by authentication method (token, workato_idp)")
+	return cmd
+}
+
+func newMCPServersGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <handle>",
+		Short: "Get MCP server details",
+		Example: `  wk mcp servers get mcps-AYcNrsC8-Dd8-AB
+  wk mcp servers get mcps-AYcNrsC8-Dd8-AB --json`,
+		Args: requireArgs(1, "server handle is required, e.g.: wk mcp servers get <handle>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			srv, err := client.MCPServers().Get(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, srv)
+			}
+
+			fmt.Fprintf(os.Stdout, "ID:          %s\n", srv.ID)
+			fmt.Fprintf(os.Stdout, "Name:        %s\n", srv.Name)
+			if srv.Description != "" {
+				fmt.Fprintf(os.Stdout, "Description: %s\n", srv.Description)
+			}
+			fmt.Fprintf(os.Stdout, "Auth Type:   %s\n", srv.AuthType)
+			fmt.Fprintf(os.Stdout, "Tools:       %d\n", srv.ToolsCount)
+			fmt.Fprintf(os.Stdout, "Project ID:  %d\n", srv.ProjectID)
+			fmt.Fprintf(os.Stdout, "Folder ID:   %d\n", srv.FolderID)
+			if srv.MCPURL != "" {
+				fmt.Fprintf(os.Stdout, "MCP URL:     %s\n", srv.MCPURL)
+			}
+			if srv.APICollection != nil {
+				fmt.Fprintf(os.Stdout, "Collection:  %s (ID: %d)\n", srv.APICollection.Name, srv.APICollection.ID)
+			}
+			if len(srv.Folders) > 0 {
+				fmt.Fprintf(os.Stdout, "Folders:\n")
+				for _, f := range srv.Folders {
+					fmt.Fprintf(os.Stdout, "  - %s (ID: %d)\n", f.Name, f.ID)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func newMCPServersCreateCmd() *cobra.Command {
+	var name, description, collection string
+	var folderID int
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an MCP server",
+		Example: `  wk mcp servers create --name "my-server" --folder-id 42 --collection "my-api-collection"
+  wk mcp servers create --name "my-server" --folder-id 42 --collection 1810
+  wk mcp servers create --name "my-server" --folder-id 42 --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			if name == "" {
+				return fmt.Errorf("--name is required")
+			}
+			if !cmd.Flags().Changed("folder-id") {
+				return fmt.Errorf("--folder-id is required")
+			}
+
+			var assetID *int
+			if collection != "" {
+				id, err := resolveMCPCollection(cmd.Context(), client, collection)
+				if err != nil {
+					return err
+				}
+				assetID = &id
+			}
+
+			srv, err := client.MCPServers().Create(cmd.Context(), name, folderID, description, assetID)
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, srv)
+			}
+
+			fmt.Fprintf(os.Stderr, "Created MCP server %q (ID: %s)\n", srv.Name, srv.ID)
+			if srv.MCPURL != "" {
+				fmt.Fprintln(os.Stdout, srv.MCPURL)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Server name")
+	cmd.Flags().IntVar(&folderID, "folder-id", 0, "Folder ID (required)")
+	cmd.Flags().StringVar(&collection, "collection", "", "API collection (name or ID)")
+	cmd.Flags().StringVar(&description, "description", "", "Server description")
+	return cmd
+}
+
+// resolveMCPCollection resolves a collection flag value to an integer ID.
+// Accepts either a numeric ID or a collection name (resolved via API).
+func resolveMCPCollection(ctx context.Context, client api.Client, value string) (int, error) {
+	if id, err := strconv.Atoi(value); err == nil {
+		return id, nil
+	}
+	return resolveCollectionName(ctx, client, value)
+}
+
+func newMCPServersUpdateCmd() *cobra.Command {
+	var name, description, authType string
+	var folderID int
+
+	cmd := &cobra.Command{
+		Use:   "update <handle>",
+		Short: "Update an MCP server",
+		Example: `  wk mcp servers update mcps-AYcNrsC8-Dd8-AB --name "new-name"
+  wk mcp servers update mcps-AYcNrsC8-Dd8-AB --auth-type workato_idp --json`,
+		Args: requireArgs(1, "server handle is required, e.g.: wk mcp servers update <handle>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			opts := map[string]any{}
+			if cmd.Flags().Changed("name") {
+				opts["name"] = name
+			}
+			if cmd.Flags().Changed("description") {
+				opts["description"] = description
+			}
+			if cmd.Flags().Changed("auth-type") {
+				opts["auth_type"] = authType
+			}
+			if cmd.Flags().Changed("folder-id") {
+				opts["folder_id"] = folderID
+			}
+			if len(opts) == 0 {
+				return fmt.Errorf("at least one update flag is required (--name, --description, --auth-type, --folder-id)")
+			}
+
+			srv, err := client.MCPServers().Update(cmd.Context(), args[0], opts)
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, srv)
+			}
+
+			fmt.Fprintf(os.Stderr, "Updated MCP server %q (ID: %s)\n", srv.Name, srv.ID)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Server name")
+	cmd.Flags().StringVar(&description, "description", "", "Server description")
+	cmd.Flags().StringVar(&authType, "auth-type", "", "Authentication type (token, workato_idp)")
+	cmd.Flags().IntVar(&folderID, "folder-id", 0, "Folder ID")
+	return cmd
+}
+
+func newMCPServersDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "delete <handle>",
+		Short:   "Delete an MCP server",
+		Example: `  wk mcp servers delete mcps-AYcNrsC8-Dd8-AB`,
+		Args:    requireArgs(1, "server handle is required, e.g.: wk mcp servers delete <handle>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			if err := client.MCPServers().Delete(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(os.Stderr, "Deleted MCP server %s\n", args[0])
+			return nil
+		},
+	}
+}
+
+func newMCPServersTokenRenewCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "token-renew <handle>",
+		Short: "Renew the authentication token for an MCP server",
+		Long: `Renew the authentication token, generating a new MCP URL with a fresh token.
+The new URL is printed to stdout. The previous token is immediately invalidated.`,
+		Example: `  wk mcp servers token-renew mcps-AYcNrsC8-Dd8-AB
+  wk mcp servers token-renew mcps-AYcNrsC8-Dd8-AB --json`,
+		Args: requireArgs(1, "server handle is required, e.g.: wk mcp servers token-renew <handle>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			srv, err := client.MCPServers().TokenRenew(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, srv)
+			}
+
+			fmt.Fprintf(os.Stderr, "Renewed token for MCP server %q (ID: %s)\n", srv.Name, srv.ID)
+			fmt.Fprintln(os.Stdout, srv.MCPURL)
+			return nil
+		},
+	}
+}
+
+func newMCPServersToolsCmd() *cobra.Command {
+	var page, perPage int
+
+	cmd := &cobra.Command{
+		Use:   "tools <handle>",
+		Short: "List tools assigned to an MCP server",
+		Example: `  wk mcp servers tools mcps-AYcNrsC8-Dd8-AB
+  wk mcp servers tools mcps-AYcNrsC8-Dd8-AB --json`,
+		Args: requireArgs(1, "server handle is required, e.g.: wk mcp servers tools <handle>"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			opts := &api.PaginationOptions{Page: page, PerPage: perPage}
+			tools, err := client.MCPServers().ListTools(cmd.Context(), args[0], opts)
+			if err != nil {
+				return err
+			}
+
+			headers := []string{"ID", "NAME", "DESCRIPTION", "FLOW ID", "ACTIVE"}
+			var rows [][]string
+			for _, t := range tools {
+				desc := ""
+				if t.Description != nil {
+					desc = *t.Description
+					if len(desc) > 60 {
+						desc = desc[:57] + "..."
+					}
+				}
+				active := "no"
+				if t.Active {
+					active = "yes"
+				}
+				rows = append(rows, []string{
+					strconv.Itoa(t.ID),
+					t.Name,
+					desc,
+					strconv.Itoa(t.FlowID),
+					active,
+				})
+			}
+			meta := output.PageMeta{Page: page, PerPage: perPage, HasNext: perPage > 0 && len(tools) == perPage}
+			return rctx.Formatter.FormatPage(os.Stdout, tools, headers, rows, meta)
+		},
+	}
+
+	cmd.Flags().IntVar(&page, "page", 0, "Page number")
+	cmd.Flags().IntVar(&perPage, "per-page", 0, "Items per page (max 100)")
+	return cmd
+}
+
+type mcpServerDef struct {
+	Name          string `json:"name"`
+	APICollection string `json:"api_collection"`
+	Description   string `json:"description"`
+	Persona       string `json:"persona,omitempty"`
+}
+
+func newMCPServersCreateBatchCmd() *cobra.Command {
+	var fromFile, fromCSV string
+	var folderID int
+	var dryRun, continueOnError bool
+
+	cmd := &cobra.Command{
+		Use:   "create-batch",
+		Short: "Create MCP servers in batch from a manifest or CSV",
+		Long: `Create multiple MCP servers from a JSON manifest or CSV file.
+
+JSON manifest: {"servers": [{"name": "...", "api_collection": "...", "description": "..."}]}
+CSV columns: name,api_collection,description,persona
+
+The api_collection field is resolved by name (or numeric ID) to link the server to an existing
+API collection, giving it tools automatically.`,
+		Example: `  wk mcp servers create-batch --from-file mcp-servers.json --folder-id 42
+  wk mcp servers create-batch --from-csv mcp_servers.csv --folder-id 42
+  wk mcp servers create-batch --from-file mcp-servers.json --folder-id 42 --dry-run`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			if !cmd.Flags().Changed("folder-id") {
+				return fmt.Errorf("--folder-id is required")
+			}
+
+			if fromFile == "" && fromCSV == "" {
+				return fmt.Errorf("--from-file or --from-csv is required")
+			}
+
+			var defs []mcpServerDef
+
+			if fromFile != "" {
+				data, err := os.ReadFile(fromFile)
+				if err != nil {
+					return fmt.Errorf("reading manifest: %w", err)
+				}
+				var manifest struct {
+					Servers []mcpServerDef `json:"servers"`
+				}
+				if err := json.Unmarshal(data, &manifest); err != nil {
+					return fmt.Errorf("parsing manifest: %w", err)
+				}
+				defs = manifest.Servers
+			} else {
+				parsed, err := parseMCPServerCSV(fromCSV)
+				if err != nil {
+					return err
+				}
+				defs = parsed
+			}
+
+			if len(defs) == 0 {
+				return fmt.Errorf("no server definitions found")
+			}
+
+			type resultEntry struct {
+				Name   string `json:"name"`
+				ID     string `json:"id,omitempty"`
+				MCPURL string `json:"mcp_url,omitempty"`
+				Error  string `json:"error,omitempty"`
+			}
+
+			collectionCache := make(map[string]int)
+
+			var created, failed []resultEntry
+
+			for _, def := range defs {
+				var assetID *int
+				if def.APICollection != "" {
+					id, err := resolveMCPCollectionCached(cmd.Context(), client, def.APICollection, collectionCache)
+					if err != nil {
+						if continueOnError {
+							fmt.Fprintf(os.Stderr, "FAIL  %s: %v\n", def.Name, err)
+							failed = append(failed, resultEntry{Name: def.Name, Error: err.Error()})
+							continue
+						}
+						return fmt.Errorf("%s: %w", def.Name, err)
+					}
+					assetID = &id
+				}
+
+				if dryRun {
+					collInfo := ""
+					if assetID != nil {
+						collInfo = fmt.Sprintf(", collection %d", *assetID)
+					}
+					fmt.Fprintf(os.Stderr, "[dry-run] would create: %s (folder %d%s)\n", def.Name, folderID, collInfo)
+					continue
+				}
+
+				srv, err := client.MCPServers().Create(cmd.Context(), def.Name, folderID, def.Description, assetID)
+				if err != nil {
+					if continueOnError {
+						fmt.Fprintf(os.Stderr, "FAIL  %s: %v\n", def.Name, err)
+						failed = append(failed, resultEntry{Name: def.Name, Error: err.Error()})
+						continue
+					}
+					return fmt.Errorf("creating %s: %w", def.Name, err)
+				}
+
+				fmt.Fprintf(os.Stderr, "OK    %s (ID: %s, tools: %d)\n", srv.Name, srv.ID, srv.ToolsCount)
+				created = append(created, resultEntry{Name: srv.Name, ID: srv.ID, MCPURL: srv.MCPURL})
+			}
+
+			if dryRun {
+				fmt.Fprintf(os.Stderr, "\n%d server(s) would be created\n", len(defs))
+				return nil
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, map[string]any{
+					"created": created,
+					"failed":  failed,
+				})
+			}
+
+			fmt.Fprintf(os.Stderr, "\n%d created, %d failed\n", len(created), len(failed))
+			if len(failed) > 0 {
+				return fmt.Errorf("batch completed with %d error(s)", len(failed))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "JSON manifest file")
+	cmd.Flags().StringVar(&fromCSV, "from-csv", "", "CSV file with server definitions")
+	cmd.Flags().IntVar(&folderID, "folder-id", 0, "Folder ID for all servers (required)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would be created without making API calls")
+	cmd.Flags().BoolVar(&continueOnError, "continue-on-error", false, "Continue creating remaining servers if one fails")
+	return cmd
+}
+
+func parseMCPServerCSV(csvPath string) ([]mcpServerDef, error) {
+	f, err := os.Open(csvPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening CSV: %w", err)
+	}
+	defer f.Close()
+
+	reader := csv.NewReader(f)
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("parsing CSV: %w", err)
+	}
+	if len(records) < 2 {
+		return nil, fmt.Errorf("CSV must have a header row and at least one data row")
+	}
+
+	header := records[0]
+	colIdx := make(map[string]int)
+	for i, h := range header {
+		colIdx[strings.TrimSpace(strings.ToLower(h))] = i
+	}
+
+	if _, ok := colIdx["name"]; !ok {
+		return nil, fmt.Errorf("CSV missing required column 'name' (have: %s)", strings.Join(header, ", "))
+	}
+
+	var defs []mcpServerDef
+	for _, row := range records[1:] {
+		def := mcpServerDef{
+			Name: strings.TrimSpace(row[colIdx["name"]]),
+		}
+		if idx, ok := colIdx["api_collection"]; ok && idx < len(row) {
+			def.APICollection = strings.TrimSpace(row[idx])
+		}
+		if idx, ok := colIdx["description"]; ok && idx < len(row) {
+			def.Description = strings.TrimSpace(row[idx])
+		}
+		if idx, ok := colIdx["persona"]; ok && idx < len(row) {
+			def.Persona = strings.TrimSpace(row[idx])
+		}
+		defs = append(defs, def)
+	}
+	return defs, nil
+}
+
+// resolveMCPCollectionCached resolves a collection name or ID with caching
+// across batch iterations to avoid repeated API calls.
+func resolveMCPCollectionCached(ctx context.Context, client api.Client, value string, cache map[string]int) (int, error) {
+	if cached, ok := cache[value]; ok {
+		return cached, nil
+	}
+	id, err := resolveMCPCollection(ctx, client, value)
+	if err != nil {
+		return 0, err
+	}
+	cache[value] = id
+	return id, nil
+}

--- a/internal/commands/recipe.go
+++ b/internal/commands/recipe.go
@@ -27,6 +27,7 @@ func newRecipesCmd() *cobra.Command {
 	cmd.AddCommand(newRecipesGetCmd())
 	cmd.AddCommand(newRecipesStartCmd())
 	cmd.AddCommand(newRecipesStopCmd())
+	cmd.AddCommand(newRecipesPullCmd())
 	cmd.AddCommand(newRecipesExportCmd())
 	cmd.AddCommand(newRecipesImportCmd())
 	cmd.AddCommand(newRecipesUpdateCmd())
@@ -42,6 +43,7 @@ func newRecipesCmd() *cobra.Command {
 func newRecipesListCmd() *cobra.Command {
 	var folderID int
 	var status string
+	var name string
 	var page, perPage int
 
 	cmd := &cobra.Command{
@@ -49,7 +51,7 @@ func newRecipesListCmd() *cobra.Command {
 		Short: "List recipes",
 		Example: `  wk recipes list
   wk recipes list --folder 123 --status running
-  wk recipes list --json --page 1 --per-page 50`,
+  wk recipes list --name "sync" --json --page 1 --per-page 50`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rctx, err := BuildRunContext(cmd)
 			if err != nil {
@@ -72,6 +74,17 @@ func newRecipesListCmd() *cobra.Command {
 			recipes, err := client.Recipes().List(cmd.Context(), opts)
 			if err != nil {
 				return err
+			}
+
+			if name != "" {
+				nameLower := strings.ToLower(name)
+				var filtered []api.Recipe
+				for _, r := range recipes {
+					if strings.Contains(strings.ToLower(r.Name), nameLower) {
+						filtered = append(filtered, r)
+					}
+				}
+				recipes = filtered
 			}
 
 			headers := []string{"ID", "NAME", "DESCRIPTION", "FOLDER", "RUNNING", "VERSION"}
@@ -97,6 +110,7 @@ func newRecipesListCmd() *cobra.Command {
 
 	cmd.Flags().IntVar(&folderID, "folder", 0, "Filter by folder ID")
 	cmd.Flags().StringVar(&status, "status", "all", "Filter by status (running, stopped, all)")
+	cmd.Flags().StringVar(&name, "name", "", "Filter by name (case-insensitive substring match)")
 	cmd.Flags().IntVar(&page, "page", 0, "Page number")
 	cmd.Flags().IntVar(&perPage, "per-page", 0, "Items per page")
 	return cmd
@@ -151,69 +165,113 @@ func newRecipesGetCmd() *cobra.Command {
 func newRecipesStartCmd() *cobra.Command {
 	var noWait bool
 	var pollTimeout int
+	var folderID int
 
 	cmd := &cobra.Command{
-		Use:   "start <id>",
-		Short: "Start a recipe",
+		Use:   "start <id> [id...]",
+		Short: "Start one or more recipes",
 		Example: `  wk recipes start 12345
-  wk recipes start 12345 --no-wait`,
-		Args:  requireArgs(1, "recipe ID is required, e.g.: wk recipes start <id>"),
+  wk recipes start 12345 67890 --no-wait
+  wk recipes start --folder 123`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _, err := resolveAPIClient(cmd)
 			if err != nil {
 				return err
 			}
 
-			id, err := strconv.Atoi(args[0])
+			ids, err := resolveRecipeIDs(cmd, client, args, folderID)
 			if err != nil {
-				return fmt.Errorf("invalid recipe ID: %s", args[0])
-			}
-
-			if err := client.Recipes().Start(cmd.Context(), id); err != nil {
 				return err
 			}
 
-			if noWait {
-				fmt.Fprintf(os.Stderr, "Recipe %d start requested\n", id)
-				return nil
-			}
-
-			// Poll to verify the recipe actually became active.
-			pt := pollTimeout
-			if pt > 600 {
-				pt = 600
-			}
-			timeout := time.Duration(pt) * time.Second
-			const interval = 2 * time.Second
-			deadline := time.Now().Add(timeout)
-
-			for time.Now().Before(deadline) {
-				recipe, err := client.Recipes().Get(cmd.Context(), id)
-				if err != nil {
-					return fmt.Errorf("checking recipe status: %w", err)
+			for _, id := range ids {
+				if err := client.Recipes().Start(cmd.Context(), id); err != nil {
+					return fmt.Errorf("starting recipe %d: %w", id, err)
 				}
-				if recipe.Running {
-					fmt.Fprintf(os.Stderr, "Recipe %d started and running\n", id)
-					return nil
-				}
-				time.Sleep(interval)
-			}
 
-			return fmt.Errorf("recipe %d did not become active within %s", id, timeout)
+				if noWait || len(ids) > 1 {
+					fmt.Fprintf(os.Stderr, "Recipe %d start requested\n", id)
+					continue
+				}
+
+				pt := pollTimeout
+				if pt > 600 {
+					pt = 600
+				}
+				timeout := time.Duration(pt) * time.Second
+				const interval = 2 * time.Second
+				deadline := time.Now().Add(timeout)
+
+				started := false
+				for time.Now().Before(deadline) {
+					recipe, err := client.Recipes().Get(cmd.Context(), id)
+					if err != nil {
+						return fmt.Errorf("checking recipe status: %w", err)
+					}
+					if recipe.Running {
+						fmt.Fprintf(os.Stderr, "Recipe %d started and running\n", id)
+						started = true
+						break
+					}
+					time.Sleep(interval)
+				}
+				if !started {
+					return fmt.Errorf("recipe %d did not become active within %s", id, timeout)
+				}
+			}
+			return nil
 		},
 	}
 
 	cmd.Flags().BoolVar(&noWait, "no-wait", false, "Do not wait for recipe to become active")
 	cmd.Flags().IntVar(&pollTimeout, "poll-timeout", 120, "Seconds to wait for recipe to become active (max 600)")
+	cmd.Flags().IntVar(&folderID, "folder", 0, "Start all recipes in this folder")
 	return cmd
 }
 
 func newRecipesStopCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:     "stop <id>",
-		Short:   "Stop a recipe",
-		Example: `  wk recipes stop 12345`,
-		Args:  requireArgs(1, "recipe ID is required, e.g.: wk recipes stop <id>"),
+	var folderID int
+
+	cmd := &cobra.Command{
+		Use:   "stop <id> [id...]",
+		Short: "Stop one or more recipes",
+		Example: `  wk recipes stop 12345
+  wk recipes stop 12345 67890
+  wk recipes stop --folder 123`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			ids, err := resolveRecipeIDs(cmd, client, args, folderID)
+			if err != nil {
+				return err
+			}
+
+			for _, id := range ids {
+				if err := client.Recipes().Stop(cmd.Context(), id); err != nil {
+					return fmt.Errorf("stopping recipe %d: %w", id, err)
+				}
+				fmt.Fprintf(os.Stderr, "Recipe %d stopped\n", id)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&folderID, "folder", 0, "Stop all recipes in this folder")
+	return cmd
+}
+
+func newRecipesPullCmd() *cobra.Command {
+	var outputFile string
+
+	cmd := &cobra.Command{
+		Use:   "pull <id>",
+		Short: "Pull a single recipe by ID (bypasses package export)",
+		Example: `  wk recipes pull 12345
+  wk recipes pull 12345 -o recipe.json`,
+		Args: requireArgs(1, "recipe ID is required, e.g.: wk recipes pull <id>"),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _, err := resolveAPIClient(cmd)
 			if err != nil {
@@ -225,14 +283,26 @@ func newRecipesStopCmd() *cobra.Command {
 				return fmt.Errorf("invalid recipe ID: %s", args[0])
 			}
 
-			if err := client.Recipes().Stop(cmd.Context(), id); err != nil {
+			data, err := client.Recipes().Export(cmd.Context(), id)
+			if err != nil {
 				return err
 			}
 
-			fmt.Fprintf(os.Stderr, "Recipe %d stopped\n", id)
-			return nil
+			if outputFile != "" {
+				if err := os.WriteFile(outputFile, data, 0644); err != nil {
+					return fmt.Errorf("writing file: %w", err)
+				}
+				fmt.Fprintf(os.Stderr, "Recipe %d pulled to %s\n", id, outputFile)
+				return nil
+			}
+
+			_, err = os.Stdout.Write(data)
+			return err
 		},
 	}
+
+	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Output file path")
+	return cmd
 }
 
 func newRecipesExportCmd() *cobra.Command {
@@ -394,6 +464,7 @@ func newRecipesJobsCmd() *cobra.Command {
 	cmd.Flags().StringVar(&status, "status", "all", "Filter by status (succeeded, failed, all)")
 	cmd.Flags().IntVar(&limit, "limit", 0, "Maximum number of jobs to return")
 	cmd.AddCommand(newRecipesJobsGetCmd())
+	cmd.AddCommand(newRecipesJobsRetryCmd())
 	return cmd
 }
 
@@ -466,6 +537,48 @@ func newRecipesJobsGetCmd() *cobra.Command {
 				return rctx.Formatter.FormatList(os.Stdout, headers, rows)
 			}
 			return nil
+		},
+	}
+}
+
+func newRecipesJobsRetryCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "retry <recipe-id> <job-id> [job-id...]",
+		Short: "Retry (repeat) one or more jobs using the latest recipe version",
+		Example: `  wk recipes jobs retry 12345 j-abc123
+  wk recipes jobs retry 12345 j-abc123 j-def456 --json`,
+		Args: cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			recipeID, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid recipe ID: %s", args[0])
+			}
+
+			jobIDs := args[1:]
+			result, err := client.Recipes().RepeatJobs(cmd.Context(), recipeID, jobIDs)
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, result)
+			}
+
+			headers := []string{"JOB ID", "STATUS", "ERROR"}
+			var rows [][]string
+			for _, r := range result.Results {
+				rows = append(rows, []string{r.JobID, r.Status, r.Error})
+			}
+			return rctx.Formatter.FormatList(os.Stdout, headers, rows)
 		},
 	}
 }
@@ -821,6 +934,36 @@ func metaMatchesRecipe(meta *sync.AssetMeta, recipeName string) bool {
 		return false
 	}
 	return meta.RecipeName != "" && meta.RecipeName == recipeName
+}
+
+// resolveRecipeIDs returns a list of recipe IDs from positional args and/or --folder.
+func resolveRecipeIDs(cmd *cobra.Command, client api.Client, args []string, folderID int) ([]int, error) {
+	if len(args) == 0 && !cmd.Flags().Changed("folder") {
+		return nil, fmt.Errorf("recipe ID(s) or --folder is required")
+	}
+
+	var ids []int
+	for _, a := range args {
+		id, err := strconv.Atoi(a)
+		if err != nil {
+			return nil, fmt.Errorf("invalid recipe ID: %s", a)
+		}
+		ids = append(ids, id)
+	}
+
+	if cmd.Flags().Changed("folder") {
+		recipes, err := client.Recipes().List(cmd.Context(), &api.RecipeListOptions{FolderID: &folderID})
+		if err != nil {
+			return nil, fmt.Errorf("listing recipes in folder %d: %w", folderID, err)
+		}
+		for _, r := range recipes {
+			ids = append(ids, r.ID)
+		}
+		if len(ids) == 0 {
+			return nil, fmt.Errorf("no recipes found in folder %d", folderID)
+		}
+	}
+	return ids, nil
 }
 
 // newRecipesVersionsCmd is the parent of the versions-management subtree.

--- a/internal/commands/sync.go
+++ b/internal/commands/sync.go
@@ -32,8 +32,9 @@ func resolveSyncEntries(cfg *config.Config, folder string) ([]config.SyncEntry, 
 
 func newPullCmd() *cobra.Command {
 	var (
-		flagFolder string
-		flagForce  bool
+		flagFolder     string
+		flagForce      bool
+		flagSkipErrors bool
 	)
 
 	cmd := &cobra.Command{
@@ -41,7 +42,8 @@ func newPullCmd() *cobra.Command {
 		Short: "Pull remote assets to local project",
 		Long:  "Download assets from the Workato workspace into the local project directory.",
 		Example: `  wk pull
-  wk pull --folder "Marketing Recipes" --force --json`,
+  wk pull --folder "Marketing Recipes" --force --json
+  wk pull --skip-errors`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rctx, err := BuildRunContext(cmd)
 			if err != nil {
@@ -64,7 +66,7 @@ func newPullCmd() *cobra.Command {
 			engine := sync.NewSyncEngine(rctx.ProjectRoot, rctx.Config, client)
 			var allResults []sync.PullResult
 			for _, entry := range entries {
-				results, err := engine.Pull(entry, flagForce)
+				results, err := engine.Pull(entry, flagForce, flagSkipErrors)
 				if err != nil {
 					return err
 				}
@@ -81,7 +83,8 @@ func newPullCmd() *cobra.Command {
 			headers := []string{"FILE", "ACTION"}
 			var rows [][]string
 			for _, r := range allResults {
-				rows = append(rows, []string{r.FilePath, r.Action})
+				row := []string{r.FilePath, r.Action}
+				rows = append(rows, row)
 			}
 			return rctx.Formatter.FormatList(os.Stdout, headers, rows)
 		},
@@ -89,6 +92,7 @@ func newPullCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&flagFolder, "folder", "", "Sync entry filter (server_path or local_path)")
 	cmd.Flags().BoolVar(&flagForce, "force", false, "Overwrite local modifications")
+	cmd.Flags().BoolVar(&flagSkipErrors, "skip-errors", false, "Continue past per-file extraction errors")
 
 	return cmd
 }

--- a/internal/commands/workspace.go
+++ b/internal/commands/workspace.go
@@ -18,6 +18,7 @@ func newWorkspaceCmd() *cobra.Command {
 	cmd.AddCommand(newWorkspaceInfoCmd())
 	cmd.AddCommand(newWorkspaceUsersCmd())
 	cmd.AddCommand(newWorkspaceAuditLogCmd())
+	cmd.AddCommand(newWorkspacePropertiesCmd())
 	return cmd
 }
 
@@ -149,4 +150,94 @@ func newWorkspaceAuditLogCmd() *cobra.Command {
 	cmd.Flags().StringVar(&until, "until", "", "End date (RFC3339)")
 	cmd.Flags().StringVar(&action, "action", "", "Filter by event type")
 	return cmd
+}
+
+func newWorkspacePropertiesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "properties",
+		Short: "Manage workspace environment properties",
+	}
+	cmd.AddCommand(newWorkspacePropertiesListCmd())
+	cmd.AddCommand(newWorkspacePropertiesSetCmd())
+	return cmd
+}
+
+func newWorkspacePropertiesListCmd() *cobra.Command {
+	var prefix string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List environment properties",
+		Example: `  wk workspace properties list --prefix app.
+  wk workspace properties list --json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			rctx, err := BuildRunContext(cmd)
+			if err != nil {
+				return err
+			}
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			props, err := client.Workspace().ListProperties(cmd.Context(), prefix)
+			if err != nil {
+				return err
+			}
+
+			if flagJSON {
+				return rctx.Formatter.Format(os.Stdout, props)
+			}
+
+			if len(props) == 0 {
+				if !rctx.Quiet {
+					fmt.Fprintln(os.Stderr, "No properties found.")
+				}
+				return nil
+			}
+
+			headers := []string{"KEY", "VALUE"}
+			var rows [][]string
+			for k, v := range props {
+				rows = append(rows, []string{k, v})
+			}
+			return rctx.Formatter.FormatList(os.Stdout, headers, rows)
+		},
+	}
+
+	cmd.Flags().StringVar(&prefix, "prefix", "", "Filter by key prefix (required by API)")
+	_ = cmd.MarkFlagRequired("prefix")
+	return cmd
+}
+
+func newWorkspacePropertiesSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <key> <value> [key value...]",
+		Short: "Set environment properties (upsert)",
+		Example: `  wk workspace properties set app.env production
+  wk workspace properties set db.host localhost db.port 5432`,
+		Args: cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args)%2 != 0 {
+				return fmt.Errorf("arguments must be key-value pairs (got %d args)", len(args))
+			}
+
+			client, _, err := resolveAPIClient(cmd)
+			if err != nil {
+				return err
+			}
+
+			props := make(map[string]string, len(args)/2)
+			for i := 0; i < len(args); i += 2 {
+				props[args[i]] = args[i+1]
+			}
+
+			if err := client.Workspace().SetProperties(cmd.Context(), props); err != nil {
+				return err
+			}
+
+			fmt.Fprintf(os.Stderr, "Set %d property(ies)\n", len(props))
+			return nil
+		},
+	}
 }

--- a/internal/sync/pull.go
+++ b/internal/sync/pull.go
@@ -20,9 +20,11 @@ import (
 type PullResult struct {
 	FilePath string `json:"file_path"`
 	// Action is one of: "created", "updated", "unchanged", "skipped",
-	// "deleted" (server-side delete reconciled locally), or "orphaned"
-	// (server-side deleted but local copy was modified — kept on disk).
+	// "deleted" (server-side delete reconciled locally), "orphaned"
+	// (server-side deleted but local copy was modified — kept on disk),
+	// or "error" (per-file failure when --skip-errors is active).
 	Action string `json:"action"`
+	Error  string `json:"error,omitempty"`
 }
 
 // Pull downloads remote assets to the local project directory.
@@ -32,7 +34,7 @@ type PullResult struct {
 // are NOT conflicts: reconcileDeletions reports them as "orphaned" and
 // leaves them on disk untouched. That narrower semantic means the
 // overwrite check must run after the zip is in hand, not before.
-func (e *SyncEngine) Pull(entry config.SyncEntry, force bool) ([]PullResult, error) {
+func (e *SyncEngine) Pull(entry config.SyncEntry, force, skipErrors bool) ([]PullResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -93,7 +95,7 @@ func (e *SyncEngine) Pull(entry config.SyncEntry, force bool) ([]PullResult, err
 	}
 
 	// Extract and write files.
-	results, seen, err := e.extractZip(zipData, localDir, entry.ServerPath)
+	results, seen, err := e.extractZip(zipData, localDir, entry.ServerPath, skipErrors)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +116,7 @@ func (e *SyncEngine) Pull(entry config.SyncEntry, force bool) ([]PullResult, err
 // files. Returns the PullResult list and a set of asset paths (relative to
 // localDir, native separator) that the zip contained — the caller uses the
 // set to reconcile server-side deletions against existing meta files.
-func (e *SyncEngine) extractZip(zipData []byte, localDir string, serverPath string) ([]PullResult, map[string]bool, error) {
+func (e *SyncEngine) extractZip(zipData []byte, localDir string, serverPath string, skipErrors bool) ([]PullResult, map[string]bool, error) {
 	r, err := zip.NewReader(bytes.NewReader(zipData), int64(len(zipData)))
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening zip: %w", err)
@@ -135,98 +137,92 @@ func (e *SyncEngine) extractZip(zipData []byte, localDir string, serverPath stri
 			continue
 		}
 
-		rc, err := f.Open()
-		if err != nil {
-			return nil, nil, fmt.Errorf("opening %s in zip: %w", f.Name, err)
-		}
-		data, err := io.ReadAll(rc)
-		rc.Close()
-		if err != nil {
-			return nil, nil, fmt.Errorf("reading %s in zip: %w", f.Name, err)
-		}
-
-		// Normalize zip path.
 		relPath := filepath.ToSlash(f.Name)
 		relPath = strings.TrimPrefix(relPath, "/")
-
-		// Track in the seen-set using the native-separator form so it
-		// lines up with FindMetaFiles keys, which come from filepath.Rel.
 		assetRel := filepath.FromSlash(relPath)
 		seen[assetRel] = true
 
-		// Consult .wkignore using the project-root-relative path.
-		absPath := filepath.Join(localDir, assetRel)
-		if projectRel, rerr := e.projectRel(absPath); rerr == nil {
-			if ignore.ShouldSkip(projectRel, false) {
-				results = append(results, PullResult{FilePath: relPath, Action: "skipped"})
-				continue
-			}
-		}
-
-		// Normalize JSON to prevent phantom diffs from server-side reformatting.
-		if isJSON(relPath) {
-			if normalized, err := normalizeJSON(data); err == nil {
-				data = normalized
-			}
-		}
-
-		newHash := ComputeHash(data)
-
-		// Determine action.
-		action := "created"
-		if existing, err := os.ReadFile(absPath); err == nil {
-			if ComputeHash(existing) == newHash {
-				action = "unchanged"
-			} else {
-				action = "updated"
-			}
-		}
-
-		if action != "unchanged" {
-			// Ensure parent directory exists.
-			if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
-				return nil, nil, fmt.Errorf("creating directory for %s: %w", absPath, err)
-			}
-			if err := os.WriteFile(absPath, data, 0644); err != nil {
-				return nil, nil, fmt.Errorf("writing %s: %w", absPath, err)
-			}
-		}
-
-		// Write/update sidecar meta under .wk/. Extract recipe name from
-		// the JSON body when possible so wk recipes delete (and similar
-		// local-cleanup paths) can match metas to server recipes reliably,
-		// regardless of how the filename was chosen. The package-manifest
-		// zip does not carry server-side IDs — name is the only stable
-		// key available here.
-		assetType := inferAssetType(relPath)
-		meta := &AssetMeta{
-			ServerPath:   serverPath + "/" + relPath,
-			ZipName:      f.Name,
-			Folder:       filepath.Dir(relPath),
-			Type:         assetType,
-			ContentHash:  newHash,
-			LastPulledAt: time.Now().UTC(),
-		}
-		if assetType == "recipe" && isJSON(relPath) {
-			if name := extractJSONStringField(data, "name"); name != "" {
-				meta.RecipeName = name
-			}
-		}
-		metaPath, err := MetaPath(e.projectRoot, absPath)
+		res, err := e.extractOneFile(f, localDir, serverPath, relPath, assetRel, ignore)
 		if err != nil {
-			return nil, nil, fmt.Errorf("meta path for %s: %w", relPath, err)
+			if !skipErrors {
+				return nil, nil, err
+			}
+			results = append(results, PullResult{FilePath: relPath, Action: "error", Error: err.Error()})
+			continue
 		}
-		if err := WriteMeta(metaPath, meta); err != nil {
-			return nil, nil, fmt.Errorf("writing meta for %s: %w", relPath, err)
-		}
-
-		results = append(results, PullResult{
-			FilePath: relPath,
-			Action:   action,
-		})
+		results = append(results, res)
 	}
 
 	return results, seen, nil
+}
+
+func (e *SyncEngine) extractOneFile(f *zip.File, localDir, serverPath, relPath, assetRel string, ignore *Matcher) (PullResult, error) {
+	absPath := filepath.Join(localDir, assetRel)
+	if projectRel, rerr := e.projectRel(absPath); rerr == nil {
+		if ignore.ShouldSkip(projectRel, false) {
+			return PullResult{FilePath: relPath, Action: "skipped"}, nil
+		}
+	}
+
+	rc, err := f.Open()
+	if err != nil {
+		return PullResult{}, fmt.Errorf("opening %s in zip: %w", f.Name, err)
+	}
+	data, err := io.ReadAll(rc)
+	rc.Close()
+	if err != nil {
+		return PullResult{}, fmt.Errorf("reading %s in zip: %w", f.Name, err)
+	}
+
+	if isJSON(relPath) {
+		if normalized, nerr := normalizeJSON(data); nerr == nil {
+			data = normalized
+		}
+	}
+
+	newHash := ComputeHash(data)
+
+	action := "created"
+	if existing, rerr := os.ReadFile(absPath); rerr == nil {
+		if ComputeHash(existing) == newHash {
+			action = "unchanged"
+		} else {
+			action = "updated"
+		}
+	}
+
+	if action != "unchanged" {
+		if err := os.MkdirAll(filepath.Dir(absPath), 0755); err != nil {
+			return PullResult{}, fmt.Errorf("creating directory for %s: %w", absPath, err)
+		}
+		if err := os.WriteFile(absPath, data, 0644); err != nil {
+			return PullResult{}, fmt.Errorf("writing %s: %w", absPath, err)
+		}
+	}
+
+	assetType := inferAssetType(relPath)
+	meta := &AssetMeta{
+		ServerPath:   serverPath + "/" + relPath,
+		ZipName:      f.Name,
+		Folder:       filepath.Dir(relPath),
+		Type:         assetType,
+		ContentHash:  newHash,
+		LastPulledAt: time.Now().UTC(),
+	}
+	if assetType == "recipe" && isJSON(relPath) {
+		if name := extractJSONStringField(data, "name"); name != "" {
+			meta.RecipeName = name
+		}
+	}
+	metaPath, err := MetaPath(e.projectRoot, absPath)
+	if err != nil {
+		return PullResult{}, fmt.Errorf("meta path for %s: %w", relPath, err)
+	}
+	if err := WriteMeta(metaPath, meta); err != nil {
+		return PullResult{}, fmt.Errorf("writing meta for %s: %w", relPath, err)
+	}
+
+	return PullResult{FilePath: relPath, Action: action}, nil
 }
 
 // zipAssetPaths returns the set of asset paths (relative to the zip root,

--- a/internal/sync/pull.go
+++ b/internal/sync/pull.go
@@ -140,6 +140,16 @@ func (e *SyncEngine) extractZip(zipData []byte, localDir string, serverPath stri
 		relPath := filepath.ToSlash(f.Name)
 		relPath = strings.TrimPrefix(relPath, "/")
 		assetRel := filepath.FromSlash(relPath)
+
+		// Zip Slip guard: reject entries that resolve outside localDir.
+		if !isInsideDir(filepath.Join(localDir, assetRel), localDir) {
+			if !skipErrors {
+				return nil, nil, fmt.Errorf("zip entry %q resolves outside target directory", f.Name)
+			}
+			results = append(results, PullResult{FilePath: relPath, Action: "error", Error: "path traversal detected"})
+			continue
+		}
+
 		seen[assetRel] = true
 
 		res, err := e.extractOneFile(f, localDir, serverPath, relPath, assetRel, ignore)
@@ -358,6 +368,13 @@ func (e *SyncEngine) reconcileDeletions(localDir string, seen map[string]bool) (
 		}
 	}
 	return results, nil
+}
+
+// isInsideDir returns true when absPath is inside baseDir (after cleaning
+// both). Prevents zip-slip: a zip entry containing ".." could otherwise
+// escape the extraction root.
+func isInsideDir(absPath, baseDir string) bool {
+	return strings.HasPrefix(filepath.Clean(absPath)+string(os.PathSeparator), filepath.Clean(baseDir)+string(os.PathSeparator))
 }
 
 // isJSON returns true if the file path has a .json extension.

--- a/internal/sync/pull_test.go
+++ b/internal/sync/pull_test.go
@@ -149,7 +149,7 @@ func TestExtractZip_PopulatesRecipeNameFromJSONBody(t *testing.T) {
 		"notes.txt":             []byte("not a recipe"),
 	})
 
-	results, seen, err := engine.extractZip(zipData, localDir, "Recipes/slack")
+	results, seen, err := engine.extractZip(zipData, localDir, "Recipes/slack", false)
 	if err != nil {
 		t.Fatalf("extractZip: %v", err)
 	}


### PR DESCRIPTION
Major features added:

API Collections & Endpoints -
  - Collections create (from file/project)
  - Endpoints list/create (resolve recipe name--> flow id)
  - API Client command namespace added (create/get/list/delete, key mgmt)

MCP Management -
  - MCP Servers command namespace added (get/list/create/update/delete, token mgmt)
  - MCP server tool mgmt

Workspace Properties:
  - Workspace Properties command namespace added (list/set)

Recipe commands:
  - Bulk start/stop recipe support added
  - Job retry support added
  - `--name` flag filter for `wk recipes list`

Other bug fixes/enhancements:
  - Auth status (profile flag now reflects active profile)
  - Batch/file-based create (API Collections, MCP Servers)
  - `--skip-errors` support on `wk pull`

Thank you to Matt Palmer (& Yoda!) for the excellent feedback and feature input.